### PR TITLE
fix: replace javax with jakarta on imports

### DIFF
--- a/study/src/main/java/cache/com/example/GreetingController.java
+++ b/study/src/main/java/cache/com/example/GreetingController.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 @Controller
 public class GreetingController {

--- a/study/src/main/java/cache/com/example/version/ResourceVersion.java
+++ b/study/src/main/java/cache/com/example/version/ResourceVersion.java
@@ -2,7 +2,7 @@ package cache.com.example.version;
 
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 


### PR DESCRIPTION
- `javax`로 작성된 import가 dependency에 존재하지 않아서, `jakarta` 버전으로 import문을 수정합니다.