### PR TITLE
fix: remove implementation logback-classic on gradle

### DIFF
--- a/study/build.gradle
+++ b/study/build.gradle
@@ -19,7 +19,6 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
-    implementation 'ch.qos.logback:logback-classic:1.5.7'
     implementation 'org.apache.commons:commons-lang3:3.14.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
     implementation 'pl.allegro.tech.boot:handlebars-spring-boot-starter:0.4.1'


### PR DESCRIPTION
### 문제 상황
- `Thread` 학습 테스트를 위해 `thread.stage2.App` 을 실행하면 `NoSuchFieldError` 발생
```
Logging system failed to initialize using configuration from 'null'
java.lang.NoSuchFieldError: Class ch.qos.logback.classic.LoggerContext does not have member field 'java.util.concurrent.locks.ReentrantLock configurationLock'
	at ch.qos.logback.classic.LoggerContext.stop(LoggerContext.java:364)
...
10:45:41.445 [main] ERROR org.springframework.boot.SpringApplication -- Application run failed
```

### 원인

- `ch.qos.logback:logback-classic` 최신 버전 `1.5.7` 이 `Spring Boot` `3.3.0` 과 호환되지 않는 것으로 추정
- 커밋 https://github.com/woowacourse/java-http/commit/92a84f2d5f81a84e4164a1f8ec1e8db337ba06a9 에서 버전 업데이트가 이루어진 이력이 있음

### 변경 사항

- `org.springframework.boot:spring-boot-starter-logging:3.3.0` 에서 `logback-classic 1.5.6` 을 포함하고 있으므로 `implementation logback` 제거

#### Before
![1](https://github.com/user-attachments/assets/4f2e8b78-5f3c-4a88-88a6-f15e22158d02)

#### After
![2](https://github.com/user-attachments/assets/3489f31c-ee3b-4aa4-9449-8d093f32f55a)