### PR TITLE
fix: add threads min-spare configuration on properties

### DIFF
--- a/study/src/main/resources/application.yml
+++ b/study/src/main/resources/application.yml
@@ -6,4 +6,5 @@ server:
     accept-count: 1
     max-connections: 1
     threads:
+      min-spare: 2
       max: 2


### PR DESCRIPTION
### 문제 상황
- `Thread` 학습 테스트를 위해 `thread.stage2.App` 을 실행하면 발생 아래 오류 발생
![image](https://github.com/user-attachments/assets/9b3dd9a4-0021-4bec-890d-b632cff89a27)

### 원인
- `Spring Boot 3.3.0` 버전 에서 `application.yml` 에 기존 설정 되어 있던 `Tomcat` 스레드 설정 값 `server.tomcat.threads.max` 이 `2` 로써 최소 스레드 유지 개수보다 낮게 설정 되어 있음

### 변경사항
- `server.tomcat.threads.min-spare=2` 를 추가하여 `max` 와 같도록 설정 (기본값: 10)

### 참고자료
- https://github.com/spring-projects/spring-boot/issues/40945

> 참고자료에 따르면 이 문제는 `Spring Boot 3.3.1` 에 해결되었다고 합니다.

`CachedThreadPool` 을 이해하기에도 좋은 옵션이지 않을까 생각하였습니다.