### PR TITLE
fix: replace handlebars template engine deps

### DIFF
--- a/study/build.gradle
+++ b/study/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.apache.commons:commons-lang3:3.14.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
-    implementation 'pl.allegro.tech.boot:handlebars-spring-boot-starter:0.4.1'
+    implementation 'com.github.jknack:handlebars-springmvc:4.4.0'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.assertj:assertj-core:3.26.0'

--- a/study/src/main/java/cache/com/example/version/HandlebarsConfig.java
+++ b/study/src/main/java/cache/com/example/version/HandlebarsConfig.java
@@ -1,0 +1,26 @@
+package cache.com.example.version;
+
+import com.github.jknack.handlebars.springmvc.HandlebarsViewResolver;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.ViewResolver;
+
+@Configuration
+public class HandlebarsConfig {
+
+    private final VersionHandlebarsHelper versionHandlebarsHelper;
+
+    public HandlebarsConfig(VersionHandlebarsHelper versionHandlebarsHelper) {
+        this.versionHandlebarsHelper = versionHandlebarsHelper;
+    }
+
+    @Bean
+    public ViewResolver handlebarsViewResolver() {
+        HandlebarsViewResolver viewResolver = new HandlebarsViewResolver();
+        viewResolver.registerHelper("staticUrls", versionHandlebarsHelper);
+        viewResolver.setPrefix("classpath:/templates/");
+        viewResolver.setSuffix(".html");
+
+        return viewResolver;
+    }
+}

--- a/study/src/main/java/cache/com/example/version/VersionHandlebarsHelper.java
+++ b/study/src/main/java/cache/com/example/version/VersionHandlebarsHelper.java
@@ -1,13 +1,14 @@
 package cache.com.example.version;
 
+import com.github.jknack.handlebars.Helper;
 import com.github.jknack.handlebars.Options;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import pl.allegro.tech.boot.autoconfigure.handlebars.HandlebarsHelper;
+import org.springframework.stereotype.Component;
 
-@HandlebarsHelper
-public class VersionHandlebarsHelper {
+@Component
+public class VersionHandlebarsHelper implements Helper<Object> {
 
     private static final Logger log = LoggerFactory.getLogger(VersionHandlebarsHelper.class);
 
@@ -21,5 +22,10 @@ public class VersionHandlebarsHelper {
     public String staticUrls(String path, Options options) {
         log.debug("static url : {}", path);
         return String.format("/resources/%s%s", version.getVersion(), path);
+    }
+
+    @Override
+    public Object apply(Object context, Options options) {
+        return staticUrls(context.toString(), options);
     }
 }


### PR DESCRIPTION
현재 템플릿 엔진으로 사용되는 `handlebars-spring-boot-starter`는 springboot3을 지원하지 않습니다. 
`/resources/templates` 내의 템플릿을 정상적으로 로드하지 못하고, `resource-versioning.html` 내에서 `{{staticUrls}}`를 제대로 랜더링하지 못합니다.

이에 Springboot 3을 지원하는 `handlebars-springmvc` 으로 템플릿 엔진을 변경합니다.

### 변경사항
- 종속성을 `handlebars-springmvc` 로 변경
- 커스텀 `HandlebarsHelper` 등록 방법 변경에 따른 수정
- 더 이상 사용되지 않는 `application.yml`의 `handlebars.suffix` 설정 제거

---
- 레퍼런스: https://github.com/allegro/handlebars-spring-boot-starter/issues/46