### PR TITLE
[4단계- Tomcat 구현하기] 리브(김민주) 미션 제출합니다.

### DIFF
--- a/study/src/main/resources/application.yml
+++ b/study/src/main/resources/application.yml
@@ -4,7 +4,7 @@ handlebars:
 server:
   tomcat:
     accept-count: 1
-    max-connections: 1
+    max-connections: 2
     threads:
       max: 2
   compression:

--- a/study/src/test/java/thread/stage0/SynchronizationTest.java
+++ b/study/src/test/java/thread/stage0/SynchronizationTest.java
@@ -41,7 +41,7 @@ class SynchronizationTest {
 
         private int sum = 0;
 
-        public void calculate() {
+        public synchronized void calculate() {
             setSum(getSum() + 1);
         }
 

--- a/study/src/test/java/thread/stage0/ThreadPoolsTest.java
+++ b/study/src/test/java/thread/stage0/ThreadPoolsTest.java
@@ -31,8 +31,8 @@ class ThreadPoolsTest {
         executor.submit(logWithSleep("hello fixed thread pools"));
 
         // 올바른 값으로 바꿔서 테스트를 통과시키자.
-        final int expectedPoolSize = 0;
-        final int expectedQueueSize = 0;
+        final int expectedPoolSize = 2;
+        final int expectedQueueSize = 1;
 
         assertThat(expectedPoolSize).isEqualTo(executor.getPoolSize());
         assertThat(expectedQueueSize).isEqualTo(executor.getQueue().size());
@@ -46,7 +46,7 @@ class ThreadPoolsTest {
         executor.submit(logWithSleep("hello cached thread pools"));
 
         // 올바른 값으로 바꿔서 테스트를 통과시키자.
-        final int expectedPoolSize = 0;
+        final int expectedPoolSize = 3;
         final int expectedQueueSize = 0;
 
         assertThat(expectedPoolSize).isEqualTo(executor.getPoolSize());

--- a/study/src/test/java/thread/stage1/ConcurrencyTest.java
+++ b/study/src/test/java/thread/stage1/ConcurrencyTest.java
@@ -35,6 +35,9 @@ class ConcurrencyTest {
 
         // 이미 gugu로 가입한 사용자가 있어서 UserServlet.join() 메서드의 if절 조건은 false가 되고 크기는 1이다.
         // 하지만 디버거로 개별 스레드를 일시 중지하면 if절 조건이 true가 되고 크기가 2가 된다. 왜 그럴까?
+        // 💡 스레드 경합 : 두 스레드가 동일한 자원(userServlet)에 동시에 접근함.
+        // 두 스레드는 독립적으로 실행되므로, 실행 순서가 보장되지 않는다.
+        // 동기화 필요
         assertThat(userServlet.getUsers()).hasSize(1);
     }
 }

--- a/study/src/test/java/thread/stage1/UserServlet.java
+++ b/study/src/test/java/thread/stage1/UserServlet.java
@@ -11,7 +11,7 @@ public class UserServlet {
         join(user);
     }
 
-    private void join(final User user) {
+    private synchronized void join(final User user) {
         if (!users.contains(user)) {
             users.add(user);
         }

--- a/study/src/test/java/thread/stage2/AppTest.java
+++ b/study/src/test/java/thread/stage2/AppTest.java
@@ -1,11 +1,10 @@
 package thread.stage2;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.http.HttpResponse;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 class AppTest {
 
@@ -20,6 +19,50 @@ class AppTest {
      * - 스레드명(nio-8080-exec-x)으로 생성된 스레드 갯수를 파악
      * - http call count
      * - 테스트 결과값
+     * accept-count: 1 ➡️ 톰캣이 처리할 수 있는 최대 대기 큐 크기
+     * max-connections: 1 ➡️ 톰캣이 허용할 수 있는 최대 동시 연결 수
+     * threads:
+     * max: 2
+     * 2024-09-13T02:43:11.462+09:00  INFO 69799 --- [nio-8080-exec-1] thread.stage2.SampleController           : http call count : 1
+     * 2024-09-13T02:43:13.250+09:00  INFO 69799 --- [nio-8080-exec-1] thread.stage2.SampleController           : http call count : 2
+     * <p>
+     * accept-count: 5
+     * max-connections: 1
+     * threads:
+     * max: 2
+     * 2024-09-13T02:49:50.505+09:00  INFO 70353 --- [nio-8080-exec-1] thread.stage2.SampleController           : http call count : 1
+     * 2024-09-13T02:49:52.335+09:00  INFO 70353 --- [nio-8080-exec-1] thread.stage2.SampleController           : http call count : 2
+     * 2024-09-13T02:49:52.846+09:00  INFO 70353 --- [nio-8080-exec-2] thread.stage2.SampleController           : http call count : 3
+     * 2024-09-13T02:49:53.355+09:00  INFO 70353 --- [nio-8080-exec-1] thread.stage2.SampleController           : http call count : 4
+     * 2024-09-13T02:49:53.864+09:00  INFO 70353 --- [nio-8080-exec-2] thread.stage2.SampleController           : http call count : 5
+     * 2024-09-13T02:49:54.373+09:00  INFO 70353 --- [nio-8080-exec-1] thread.stage2.SampleController           : http call count : 6
+     * 💡 처음에 요청 하나 받음(max-connections: 1) 스레드가 3개 있지만 요청을 한 번에 하나만 처리할 수 있기 때문에 실행 시간도 다 다르다.
+     * 그리고 큐에 5개의 요청을 보관할 수 있기 때문에 처음에 받은 요청 1 + 큐에 있던 요청 5개 = 총 6개 처리 가능하다.
+     *
+     *     accept-count: 5
+     *     max-connections: 2
+     *     threads:
+     *       max: 2
+     * 2024-09-13T03:09:14.090+09:00  INFO 71843 --- [nio-8080-exec-1] thread.stage2.SampleController           : http call count : 1
+     * 2024-09-13T03:09:14.090+09:00  INFO 71843 --- [nio-8080-exec-2] thread.stage2.SampleController           : http call count : 2
+     * 2024-09-13T03:09:15.893+09:00  INFO 71843 --- [nio-8080-exec-2] thread.stage2.SampleController           : http call count : 3
+     * 2024-09-13T03:09:15.893+09:00  INFO 71843 --- [nio-8080-exec-1] thread.stage2.SampleController           : http call count : 4
+     * 2024-09-13T03:09:16.401+09:00  INFO 71843 --- [nio-8080-exec-1] thread.stage2.SampleController           : http call count : 5
+     * 2024-09-13T03:09:16.403+09:00  INFO 71843 --- [nio-8080-exec-2] thread.stage2.SampleController           : http call count : 6
+     * 2024-09-13T03:09:16.908+09:00  INFO 71843 --- [nio-8080-exec-1] thread.stage2.SampleController           : http call count : 7
+     * 💡 max-connections를 2로 바꾸면 한 번에 두 개씩 처리할 수 있다 그래서 두 요청들이 처리된 시간이 같다.
+     * 처음에 받은 요청 2 + 큐에 있던 요청 5 = 총 7개 처리 가능하다.
+     *
+     *     accept-count: 5
+     *     max-connections: 1
+     *     threads:
+     *       max: 5
+     * 2024-09-13T03:10:27.652+09:00  INFO 71939 --- [nio-8080-exec-3] thread.stage2.SampleController           : http call count : 2
+     * 2024-09-13T03:10:26.052+09:00  INFO 71939 --- [nio-8080-exec-4] thread.stage2.SampleController           : http call count : 3
+     * 2024-09-13T03:10:26.562+09:00  INFO 71939 --- [nio-8080-exec-5] thread.stage2.SampleController           : http call count : 4
+     * 2024-09-13T03:10:27.069+09:00  INFO 71939 --- [nio-8080-exec-1] thread.stage2.SampleController           : http call count : 5
+     * 2024-09-13T03:10:27.579+09:00  INFO 71939 --- [nio-8080-exec-2] thread.stage2.SampleController           : http call count : 6
+     * 💡 스레드가 많아도 한 번에 처리할 수 있는 요청이 하나라서 6개만 처리 가능하다.
      */
     @Test
     void test() throws Exception {

--- a/tomcat/src/main/java/com/techcourse/controller/AbstractController.java
+++ b/tomcat/src/main/java/com/techcourse/controller/AbstractController.java
@@ -13,7 +13,9 @@ public abstract class AbstractController implements Controller {
         }
         if (request.isPost()) {
             doPost(request, response);
+            return;
         }
+        throw new UnsupportedOperationException("지원하지 않는 메서드입니다.");
     }
 
     protected void doGet(HttpRequest request, HttpResponse response) throws Exception { /* NOOP */ }

--- a/tomcat/src/main/java/com/techcourse/controller/IndexController.java
+++ b/tomcat/src/main/java/com/techcourse/controller/IndexController.java
@@ -11,6 +11,6 @@ public class IndexController extends AbstractController {
         String responseBody = "Hello world!";
 
         response.setBody(new ResponseBody("text/html", responseBody));
-        response.send200Response();
+        response.set200Response();
     }
 }

--- a/tomcat/src/main/java/com/techcourse/controller/LoginController.java
+++ b/tomcat/src/main/java/com/techcourse/controller/LoginController.java
@@ -33,17 +33,14 @@ public class LoginController extends AbstractController {
         String account = request.findBodyValueByKey("account");
         String password = request.findBodyValueByKey("password");
 
-        User user = InMemoryUserRepository.findByAccount(account)
+        InMemoryUserRepository.findByAccount(account)
                 .filter(it -> it.checkPassword(password))
-                .orElse(null);
+                .ifPresentOrElse(user -> processLoginSuccess(request, response, user),
+                        () -> response.setRedirectResponse("/401.html"));
+    }
 
-        if (user == null) {
-            response.setRedirectResponse("/401.html");
-            return;
-        }
-
+    private void processLoginSuccess(HttpRequest request, HttpResponse response, User user) {
         initializeSessionIfNotExists(request, response, user);
-
         response.setRedirectResponse("/index.html");
     }
 

--- a/tomcat/src/main/java/com/techcourse/controller/LoginController.java
+++ b/tomcat/src/main/java/com/techcourse/controller/LoginController.java
@@ -48,7 +48,7 @@ public class LoginController extends AbstractController {
     }
 
     private void initializeSessionIfNotExists(HttpRequest request, HttpResponse response, User user) {
-        if (request.sessionNotExists()) {
+        if (request.checkSessionNotExists()) {
             Session session = request.getSession(true);
             session.setAttribute(SESSION_USER_ATTRIBUTE, user);
             response.setCookie(Cookie.createSessionCookie(session.getId()));

--- a/tomcat/src/main/java/com/techcourse/controller/LoginController.java
+++ b/tomcat/src/main/java/com/techcourse/controller/LoginController.java
@@ -14,7 +14,7 @@ public class LoginController extends AbstractController {
 
     @Override
     protected void doGet(HttpRequest request, HttpResponse response) throws Exception {
-        if (isLoggedIn(request, response)) {
+        if (isLoggedIn(request)) {
             response.setRedirectResponse("/index.html");
             return;
         }
@@ -22,7 +22,7 @@ public class LoginController extends AbstractController {
         response.setStaticResourceResponse("/login.html");
     }
 
-    private boolean isLoggedIn(HttpRequest request, HttpResponse response) throws IOException {
+    private boolean isLoggedIn(HttpRequest request) {
         Session session = request.getSession(false);
 
         return session != null && session.getAttribute(SESSION_USER_ATTRIBUTE) != null;

--- a/tomcat/src/main/java/com/techcourse/controller/LoginController.java
+++ b/tomcat/src/main/java/com/techcourse/controller/LoginController.java
@@ -15,11 +15,11 @@ public class LoginController extends AbstractController {
     @Override
     protected void doGet(HttpRequest request, HttpResponse response) throws Exception {
         if (isLoggedIn(request, response)) {
-            response.sendRedirect("/index.html");
+            response.setRedirectResponse("/index.html");
             return;
         }
 
-        response.sendStaticResourceResponse("/login.html");
+        response.setStaticResourceResponse("/login.html");
     }
 
     private boolean isLoggedIn(HttpRequest request, HttpResponse response) throws IOException {
@@ -38,13 +38,13 @@ public class LoginController extends AbstractController {
                 .orElse(null);
 
         if (user == null) {
-            response.sendRedirect("/401.html");
+            response.setRedirectResponse("/401.html");
             return;
         }
 
         initializeSessionIfNotExists(request, response, user);
 
-        response.sendRedirect("/index.html");
+        response.setRedirectResponse("/index.html");
     }
 
     private void initializeSessionIfNotExists(HttpRequest request, HttpResponse response, User user) {

--- a/tomcat/src/main/java/com/techcourse/controller/LoginController.java
+++ b/tomcat/src/main/java/com/techcourse/controller/LoginController.java
@@ -14,7 +14,10 @@ public class LoginController extends AbstractController {
 
     @Override
     protected void doGet(HttpRequest request, HttpResponse response) throws Exception {
-        if (isLoggedIn(request, response)) return;
+        if (isLoggedIn(request, response)) {
+            response.sendRedirect("/index.html");
+            return;
+        }
 
         response.sendStaticResourceResponse("/login.html");
     }
@@ -22,11 +25,7 @@ public class LoginController extends AbstractController {
     private boolean isLoggedIn(HttpRequest request, HttpResponse response) throws IOException {
         Session session = request.getSession(false);
 
-        if (session == null || session.getAttribute(SESSION_USER_ATTRIBUTE) == null) {
-            return false;
-        }
-        response.sendRedirect("/index.html");
-        return true;
+        return session != null && session.getAttribute(SESSION_USER_ATTRIBUTE) != null;
     }
 
     @Override

--- a/tomcat/src/main/java/com/techcourse/controller/RegisterController.java
+++ b/tomcat/src/main/java/com/techcourse/controller/RegisterController.java
@@ -9,7 +9,7 @@ public class RegisterController extends AbstractController {
 
     @Override
     protected void doGet(HttpRequest request, HttpResponse response) throws Exception {
-        response.sendStaticResourceResponse("/register.html");
+        response.setStaticResourceResponse("/register.html");
     }
 
     @Override
@@ -21,7 +21,7 @@ public class RegisterController extends AbstractController {
         validateInput(account, password, email);
 
         InMemoryUserRepository.save(new User(account, password, email));
-        response.sendRedirect("/index.html");
+        response.setRedirectResponse("/index.html");
     }
 
     private void validateInput(String account, String password, String email) {

--- a/tomcat/src/main/java/com/techcourse/controller/StaticResourceController.java
+++ b/tomcat/src/main/java/com/techcourse/controller/StaticResourceController.java
@@ -7,6 +7,6 @@ public class StaticResourceController extends AbstractController {
 
     @Override
     protected void doGet(HttpRequest request, HttpResponse response) throws Exception {
-        response.sendStaticResourceResponse(request.getPath());
+        response.setStaticResourceResponse(request.getPath());
     }
 }

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -70,10 +70,8 @@ public class Connector implements Runnable {
         if (connection == null) {
             return;
         }
-        executor.submit(() -> {
-            var processor = new Http11Processor(connection);
-            processor.run();
-        });
+        var processor = new Http11Processor(connection);
+        executor.execute(processor);
     }
 
     public void stop() {

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -16,7 +16,7 @@ public class Connector implements Runnable {
 
     private static final int DEFAULT_PORT = 8080;
     private static final int DEFAULT_ACCEPT_COUNT = 100;
-    private static final int DEFAULT_MAX_THREADS = 10;
+    private static final int DEFAULT_MAX_THREADS = 250;
 
     private final ServerSocket serverSocket;
     private final ExecutorService executor;

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -1,13 +1,14 @@
 package org.apache.catalina.connector;
 
-import org.apache.coyote.http11.Http11Processor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.coyote.http11.Http11Processor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Connector implements Runnable {
 
@@ -15,16 +16,19 @@ public class Connector implements Runnable {
 
     private static final int DEFAULT_PORT = 8080;
     private static final int DEFAULT_ACCEPT_COUNT = 100;
+    private static final int DEFAULT_MAX_THREADS = 10;
 
     private final ServerSocket serverSocket;
+    private final ExecutorService executor;
     private boolean stopped;
 
     public Connector() {
-        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT);
+        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT, DEFAULT_MAX_THREADS);
     }
 
-    public Connector(final int port, final int acceptCount) {
+    public Connector(final int port, final int acceptCount, final int maxThreads) {
         this.serverSocket = createServerSocket(port, acceptCount);
+        this.executor = Executors.newFixedThreadPool(maxThreads);
         this.stopped = false;
     }
 
@@ -66,8 +70,10 @@ public class Connector implements Runnable {
         if (connection == null) {
             return;
         }
-        var processor = new Http11Processor(connection);
-        new Thread(processor).start();
+        executor.submit(() -> {
+            var processor = new Http11Processor(connection);
+            processor.run();
+        });
     }
 
     public void stop() {

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -32,8 +32,12 @@ public class Http11Processor implements Runnable, Processor {
         try (InputStream inputStream = connection.getInputStream();
              OutputStream outputStream = connection.getOutputStream()) {
             HttpRequest request = HttpRequest.of(inputStream);
-            HttpResponse response = new HttpResponse(outputStream);
+            HttpResponse response = new HttpResponse();
+
             RequestDispatcher.dispatchRequest(request, response);
+
+            outputStream.write(response.getResponse().getBytes());
+            outputStream.flush();
         } catch (IOException | UncheckedServletException | IllegalArgumentException e) {
             log.error(e.getMessage(), e);
         } catch (Exception e) {

--- a/tomcat/src/main/java/org/apache/coyote/http11/RequestDispatcher.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/RequestDispatcher.java
@@ -19,6 +19,6 @@ public class RequestDispatcher {
             new StaticResourceController().service(request, response);
             return;
         }
-        response.sendRedirect("/404.html");
+        response.setRedirectResponse("/404.html");
     }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/RequestMapping.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/RequestMapping.java
@@ -21,4 +21,8 @@ public class RequestMapping {
     public static Controller getController(HttpRequest request) throws Exception {
         return controllers.get(request.getPath());
     }
+
+    private RequestMapping() {
+        throw new UnsupportedOperationException("인스턴스를 생성할 수 없는 클래스입니다.");
+    }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/cookie/Cookie.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/cookie/Cookie.java
@@ -3,6 +3,7 @@ package org.apache.coyote.http11.cookie;
 public class Cookie {
 
     private static final String SESSION_COOKIE_NAME = "JSESSIONID";
+    private static final String COOKIE_NAME_VALUE_DELIMITER = "=";
 
     private final String name;
     private final String value;
@@ -17,6 +18,6 @@ public class Cookie {
     }
 
     public String getCookieString() {
-        return name + "=" + value;
+        return name + COOKIE_NAME_VALUE_DELIMITER + value;
     }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/request/HttpRequest.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/request/HttpRequest.java
@@ -59,7 +59,7 @@ public class HttpRequest {
         return body.findByKey(key);
     }
 
-    public boolean sessionNotExists() {
+    public boolean checkSessionNotExists() {
         String cookieString = headers.getCookieString();
 
         if (cookieString == null) {
@@ -71,13 +71,13 @@ public class HttpRequest {
     }
 
     public Session getSession(boolean createIfNotExists) {
-        if (sessionNotExists() && createIfNotExists) {
+        if (checkSessionNotExists() && createIfNotExists) {
             Session session = new Session();
             SessionManager.getInstance().add(session);
             return session;
         }
 
-        if (sessionNotExists()) {
+        if (checkSessionNotExists()) {
             return null;
         }
 

--- a/tomcat/src/main/java/org/apache/coyote/http11/response/HttpResponse.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/response/HttpResponse.java
@@ -2,7 +2,6 @@ package org.apache.coyote.http11.response;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.net.URL;
 import java.nio.file.Files;
 import org.apache.coyote.http11.ContentMimeType;
@@ -17,26 +16,23 @@ public class HttpResponse {
     private static final String STATIC_FILES_BASE_PATH = "static";
     private static final String FILE_EXTENSION_DELIMITER = ".";
 
-    private final OutputStream outputStream;
     private final ResponseHeaders headers;
     private StatusLine statusLine;
     private ResponseBody body;
 
     private HttpResponse(
-            OutputStream outputStream,
             HttpStatus status,
             String protocolVersion,
             ResponseHeaders headers,
             ResponseBody body
     ) {
-        this.outputStream = outputStream;
         this.statusLine = new StatusLine(protocolVersion, status);
         this.headers = headers;
         this.body = body;
     }
 
-    public HttpResponse(OutputStream outputStream) {
-        this(outputStream, null, null, new ResponseHeaders(), null);
+    public HttpResponse() {
+        this(null, null, new ResponseHeaders(), null);
     }
 
     public void setCookie(Cookie cookie) {
@@ -49,40 +45,25 @@ public class HttpResponse {
         headers.add(HttpHeaderKey.CONTENT_LENGTH, body.getContentLength());
     }
 
-    public void sendStaticResourceResponse(String urlWithExtension) throws IOException {
+    public void setStaticResourceResponse(String urlWithExtension) throws IOException {
         this.statusLine = new StatusLine(HttpStatus.OK);
         int index = urlWithExtension.lastIndexOf(FILE_EXTENSION_DELIMITER);
         String url = urlWithExtension.substring(0, index);
         String extension = urlWithExtension.substring(index + 1);
         String responseBody = readFileContent(url, extension);
         setBody(new ResponseBody(ContentMimeType.getMimeByExtension(extension), responseBody));
-        outputStream.write(getResponse().getBytes());
-        outputStream.flush();
     }
 
-    public void send200Response() throws IOException {
+    public void set200Response() throws IOException {
         this.statusLine = new StatusLine(HttpStatus.OK);
-        outputStream.write(getResponse().getBytes());
-        outputStream.flush();
     }
 
-    public void sendRedirect(String location) throws IOException {
+    public void setRedirectResponse(String location) throws IOException {
         this.statusLine = new StatusLine(HttpStatus.FOUND);
         headers.add(HttpHeaderKey.LOCATION, location);
-        outputStream.write(getResponse().getBytes());
-        outputStream.flush();
     }
 
-    private String readFileContent(String url, String extension) throws IllegalArgumentException, IOException {
-        URL resource = getClass().getClassLoader()
-                .getResource(STATIC_FILES_BASE_PATH + url + FILE_EXTENSION_DELIMITER + extension);
-        if (resource == null) {
-            throw new IllegalArgumentException(STATIC_FILES_BASE_PATH + url + FILE_EXTENSION_DELIMITER + extension + "이 존재하지 않습니다.");
-        }
-        return new String(Files.readAllBytes(new File(resource.getFile()).toPath()));
-    }
-
-    private String getResponse() {
+    public String getResponse() {
         StringBuilder responseBuilder = new StringBuilder();
         responseBuilder.append(statusLine.formatStatusLine()).append(LINE_SEPARATOR);
         responseBuilder.append(headers.getHeaderResponse()).append(LINE_SEPARATOR);
@@ -92,5 +73,14 @@ public class HttpResponse {
             responseBuilder.append(body.getValue());
         }
         return responseBuilder.toString();
+    }
+
+    private String readFileContent(String url, String extension) throws IllegalArgumentException, IOException {
+        URL resource = getClass().getClassLoader()
+                .getResource(STATIC_FILES_BASE_PATH + url + FILE_EXTENSION_DELIMITER + extension);
+        if (resource == null) {
+            throw new IllegalArgumentException(STATIC_FILES_BASE_PATH + url + FILE_EXTENSION_DELIMITER + extension + "이 존재하지 않습니다.");
+        }
+        return new String(Files.readAllBytes(new File(resource.getFile()).toPath()));
     }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/response/HttpResponse.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/response/HttpResponse.java
@@ -54,11 +54,11 @@ public class HttpResponse {
         setBody(new ResponseBody(ContentMimeType.getMimeByExtension(extension), responseBody));
     }
 
-    public void set200Response() throws IOException {
+    public void set200Response() {
         this.statusLine = new StatusLine(HttpStatus.OK);
     }
 
-    public void setRedirectResponse(String location) throws IOException {
+    public void setRedirectResponse(String location) {
         this.statusLine = new StatusLine(HttpStatus.FOUND);
         headers.add(HttpHeaderKey.LOCATION, location);
     }

--- a/tomcat/src/main/java/org/apache/coyote/http11/session/SessionManager.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/session/SessionManager.java
@@ -1,12 +1,12 @@
 package org.apache.coyote.http11.session;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.catalina.Manager;
 
 public class SessionManager implements Manager {
 
-    private static final Map<String, Session> SESSIONS = new HashMap<>();
+    private static final Map<String, Session> SESSIONS = new ConcurrentHashMap<>();
     private static final SessionManager INSTANCE = new SessionManager();
 
     public static SessionManager getInstance() {

--- a/tomcat/src/test/java/org/apache/coyote/http11/Http11ProcessorTest.java
+++ b/tomcat/src/test/java/org/apache/coyote/http11/Http11ProcessorTest.java
@@ -29,12 +29,13 @@ class Http11ProcessorTest {
             processor.process(socket);
 
             // then
+            String body = "Hello world!";
             String expected = String.join("\r\n",
                     "HTTP/1.1 200 OK ",
                     "Content-Type: text/html;charset=utf-8 ",
-                    "Content-Length: 12 ",
+                    "Content-Length: " + body.length() + " ",
                     "",
-                    "Hello world!");
+                    body);
 
             assertThat(socket.output()).isEqualToIgnoringWhitespace(expected);
         }
@@ -58,11 +59,12 @@ class Http11ProcessorTest {
 
             // then
             URL resource = getClass().getClassLoader().getResource("static/index.html");
+            Path path = new File(resource.getFile()).toPath();
             String expected = "HTTP/1.1 200 OK \r\n" +
                               "Content-Type: text/html;charset=utf-8 \r\n" +
-                              "Content-Length: 5564 \r\n" +
+                              "Content-Length: " + Files.size(path) + " \r\n" +
                               "\r\n" +
-                              new String(Files.readAllBytes(new File(resource.getFile()).toPath()));
+                              new String(Files.readAllBytes(path));
 
             assertThat(socket.output()).isEqualToIgnoringWhitespace(expected);
         }
@@ -87,10 +89,9 @@ class Http11ProcessorTest {
             // then
             URL resource = getClass().getClassLoader().getResource("static/login.html");
             Path path = new File(resource.getFile()).toPath();
-            long fileSize = Files.size(path);
             String expected = "HTTP/1.1 200 OK \r\n" +
                               "Content-Type: text/html;charset=utf-8 \r\n" +
-                              "Content-Length: " + fileSize + " \r\n" +
+                              "Content-Length: " + Files.size(path) + " \r\n" +
                               "\r\n" +
                               new String(Files.readAllBytes(path));
 
@@ -161,15 +162,16 @@ class Http11ProcessorTest {
         @Test
         void loginSuccess() throws IOException {
             // given
+            String body = "account=gugu&password=password";
             String httpRequest = String.join("\r\n",
                     "POST /login HTTP/1.1 ",
                     "Host: localhost:8080 ",
                     "Connection: keep-alive ",
-                    "Content-Length: 30",
+                    "Content-Length: " + body.length(),
                     "Content-Type: application/x-www-form-urlencoded",
                     "Accept: */*",
                     "",
-                    "account=gugu&password=password");
+                    body);
 
             StubSocket socket = new StubSocket(httpRequest);
             Http11Processor processor = new Http11Processor(socket);
@@ -191,15 +193,16 @@ class Http11ProcessorTest {
         @Test
         void loginFailure() throws IOException {
             // given
+            String body = "account=unknown&password=unknown";
             String httpRequest = String.join("\r\n",
                     "POST /login HTTP/1.1 ",
                     "Host: localhost:8080 ",
                     "Connection: keep-alive ",
-                    "Content-Length: 35",
+                    "Content-Length: " + body.length(),
                     "Content-Type: application/x-www-form-urlencoded",
                     "Accept: */*",
                     "",
-                    "account=unknown&password=unknown");
+                    body);
 
             StubSocket socket = new StubSocket(httpRequest);
             Http11Processor processor = new Http11Processor(socket);
@@ -220,15 +223,16 @@ class Http11ProcessorTest {
         @Test
         void registerSuccess() throws IOException {
             // given
+            String body = "account=newuser&password=password&email=newuser%40woowahan.com";
             String httpRequest = String.join("\r\n",
                     "POST /register HTTP/1.1 ",
                     "Host: localhost:8080 ",
                     "Connection: keep-alive ",
-                    "Content-Length: 64",
+                    "Content-Length: " + body.length(),
                     "Content-Type: application/x-www-form-urlencoded",
                     "Accept: */*",
                     "",
-                    "account=newuser&password=password&email=newuser%40woowahan.com");
+                    body);
 
             StubSocket socket = new StubSocket(httpRequest);
             Http11Processor processor = new Http11Processor(socket);

--- a/tomcat/src/test/java/org/apache/coyote/http11/request/HttpRequestTest.java
+++ b/tomcat/src/test/java/org/apache/coyote/http11/request/HttpRequestTest.java
@@ -109,7 +109,7 @@ public class HttpRequestTest {
 
     @DisplayName("응답 헤더 쿠키에 JSESSIONID가 없으면 true를 반환한다.")
     @Test
-    void sessionNotExists() throws IOException {
+    void checkSessionNotExists() throws IOException {
         String httpRequest = String.join("\r\n",
                 "GET /index.html HTTP/1.1 ",
                 "Host: localhost:8080 ",
@@ -120,12 +120,12 @@ public class HttpRequestTest {
         Socket socket = new StubSocket(httpRequest);
         HttpRequest request = HttpRequest.of(socket.getInputStream());
 
-        assertTrue(request.sessionNotExists());
+        assertTrue(request.checkSessionNotExists());
     }
 
     @DisplayName("응답 헤더 쿠키 JSESSIONID가 있으면 false를 반환한다.")
     @Test
-    void sessionNotExistsWithJSESSIONID() throws IOException {
+    void checkSessionNotExistsWithJSESSIONID() throws IOException {
         String httpRequest = String.join("\r\n",
                 "GET /index.html HTTP/1.1 ",
                 "Host: localhost:8080 ",
@@ -137,7 +137,7 @@ public class HttpRequestTest {
         Socket socket = new StubSocket(httpRequest);
         HttpRequest request = HttpRequest.of(socket.getInputStream());
 
-        assertFalse(request.sessionNotExists());
+        assertFalse(request.checkSessionNotExists());
     }
 
     @DisplayName("응답 헤더 쿠키의 JSESSIONID가 유효하면 세션을 찾아 반환한다.")

--- a/tomcat/src/test/java/org/apache/coyote/http11/response/HttpResponseTest.java
+++ b/tomcat/src/test/java/org/apache/coyote/http11/response/HttpResponseTest.java
@@ -9,17 +9,15 @@ import java.nio.file.Files;
 import org.apache.coyote.http11.cookie.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import support.StubSocket;
 
 class HttpResponseTest {
 
-    @DisplayName("정적 리소스 응답을 보낸다.")
+    @DisplayName("정적 리소스 응답을 생성한다.")
     @Test
-    void sendStaticResourceResponse() throws Exception {
-        StubSocket socket = new StubSocket();
-        HttpResponse httpResponse = new HttpResponse(socket.getOutputStream());
+    void setStaticResourceResponse() throws Exception {
+        HttpResponse httpResponse = new HttpResponse();
 
-        httpResponse.sendStaticResourceResponse("/index.html");
+        httpResponse.setStaticResourceResponse("/index.html");
 
         final URL resource = getClass().getClassLoader().getResource("static/index.html");
         var expected = "HTTP/1.1 200 OK \r\n" +
@@ -28,32 +26,30 @@ class HttpResponseTest {
                        "\r\n" +
                        new String(Files.readAllBytes(new File(resource.getFile()).toPath()));
 
-        assertThat(socket.output()).isEqualToIgnoringWhitespace(expected);
+        assertThat(httpResponse.getResponse()).isEqualToIgnoringWhitespace(expected);
     }
 
-    @DisplayName("리다이렉트 응답을 보낸다.")
+    @DisplayName("리다이렉트 응답을 생성한다.")
     @Test
-    void sendRedirect() throws IOException {
-        StubSocket socket = new StubSocket();
-        HttpResponse httpResponse = new HttpResponse(socket.getOutputStream());
+    void setRedirectResponse() throws IOException {
+        HttpResponse httpResponse = new HttpResponse();
 
-        httpResponse.sendRedirect("/index.html");
+        httpResponse.setRedirectResponse("/index.html");
         var expected = "HTTP/1.1 302 Found \r\n" +
                        "Location: /index.html \r\n" +
                        "\r\n";
 
-        assertThat(socket.output()).isEqualToIgnoringWhitespace(expected);
+        assertThat(httpResponse.getResponse()).isEqualToIgnoringWhitespace(expected);
     }
 
     @DisplayName("응답 헤더로 보낼 바디를 세팅한다.")
     @Test
     void setBody() throws IOException {
-        StubSocket socket = new StubSocket();
-        HttpResponse httpResponse = new HttpResponse(socket.getOutputStream());
+        HttpResponse httpResponse = new HttpResponse();
         ResponseBody body = new ResponseBody("text/html", "Hello world!");
 
         httpResponse.setBody(body);
-        httpResponse.send200Response();
+        httpResponse.set200Response();
 
         var expected = String.join("\r\n",
                 "HTTP/1.1 200 OK ",
@@ -62,24 +58,23 @@ class HttpResponseTest {
                 "",
                 "Hello world!");
 
-        assertThat(socket.output()).isEqualToIgnoringWhitespace(expected);
+        assertThat(httpResponse.getResponse()).isEqualToIgnoringWhitespace(expected);
     }
 
     @DisplayName("응답 헤더로 보낼 쿠키를 세팅한다.")
     @Test
     void setCookie() throws IOException {
-        StubSocket socket = new StubSocket();
-        HttpResponse httpResponse = new HttpResponse(socket.getOutputStream());
+        HttpResponse httpResponse = new HttpResponse();
         Cookie cookie = new Cookie("cookie", "very-tasty");
 
         httpResponse.setCookie(cookie);
-        httpResponse.send200Response();
+        httpResponse.set200Response();
 
         var expected = String.join("\r\n",
                 "HTTP/1.1 200 OK ",
                 "Set-Cookie: cookie=very-tasty ",
                 "");
 
-        assertThat(socket.output()).isEqualToIgnoringWhitespace(expected);
+        assertThat(httpResponse.getResponse()).isEqualToIgnoringWhitespace(expected);
     }
 }


### PR DESCRIPTION
안녕하세요, 클로버! 🍀
리브입니다. 😊

4단계 완료하여 PR 드립니다.
LMS에 적혀있는 바와 같이 학습 테스트를 꼼꼼히 하면서 스레드 풀 동작 원리를 이해하는 것에 집중 했습니다. 😊

그리고 3단계 리뷰 주신 내용도 같이 반영 완료 했습니다.
리뷰 하다가 궁금한 내용 있으시면 편하게 DM 주세요! 👍

> [의견]
개인적으로 메서드명만 봤을 땐 로그인 여부를 확인해줄 것 같은데 내부에서 setRedirect()까지 해준다고 예측하기 힘들 것 같아요.
 하지만 다른 객체의 메서드가 아니라 본인의 메서드를 호출하는거라 내부 구현을 알고 있는 상황이니 지금도 괜찮을 것 같습니다.
타당한 의견이라고 생각되신다면 수용해주시고 아니면 그대로 구현해주셔도 좋습니다! 😄

[`3bcb2bb`](https://github.com/Minjoo522/java-http/commit/3bcb2bbe5be91bfef2efa43bb23b64c4305368f7)
`isLoggedIn` 메서드가 로그인 여부만 확인하고 리다이렉트는 `doGet`에서 하도록 개선 했습니다.

---

> [의견] 만약 `orElse(null)`을 사용한다면, `ifPresentOrElse()`를 활용해볼 수 있을 것 같기도 하네요! 이것도 리브의 취향에 따라 반영 여부 결정해주세요 😄

`ifPresentOrElse()`를 사용하게 되면 아래처럼 try-catch로 감싸주는 과정이 필요해서 오히려 코드가 복잡해 보일 것 같습니다. 😭
물론 내부 로직을 다른 메서드로 추출할 수도 있지만 재사용되는 로직이 아니기 때문에 `User`를 리턴하고 null 값을 체크하는 기존 방식을 유지했습니다.

```java
InMemoryUserRepository.findByAccount(account)
        .ifPresentOrElse(u1 -> {
            initializeSessionIfNotExists(request, response, u1);
            try {
                response.setRedirectResponse("/index.html");
            } catch (IOException e) {
                throw new RuntimeException(e);
            }
        }, () -> {
            try {
                response.setRedirectResponse("/401.html");
            } catch (IOException e) {
                throw new RuntimeException(e);
            }
        });
```

---

> [질문] final을 위해서라면 바로 초기화해도 됐을텐데, static block을 사용하신 이유가 있으신가요? 생소한 구문이라 리브의 의견이 궁금해서 질문 드려요!

초기화 로직이 다른 작업을 한 곳에 모아둠으로써 다른 부분과 분리되어 있어 코드 가독성이 높아진다는 점이 좋아서 static block 사용했습니다!

---

> [질문] `OutputStream`으로 내보내는 책임을 `HttpResponse`에게 넘기신 이유가 궁금해요! 개인적인 생각으로는 Socket에게 응답을 전달해주는건 Processor의 역할에 가깝다고 생각했는데, 리브의 의견이 듣고 싶어요.

만약에 `Processor`에서 하게 될 경우 무조건 아래 순서가 지켜져야 정상적인 응답값을 보낼 수 있어서 `HttpResponse`에 넘겨주었습니다. 클로버 리뷰를 보고 좀 더 고민해 봤는데 현재 구조라면 `Http11Processor.process()`의 로직을 변경할 일이 거의 없을 것 같아서 [`9083517`](https://github.com/woowacourse/java-http/commit/9083517d4b4512bf2796903ae08c89d4970bc424) 이 커밋에서 반영했습니다.

```java
RequestDispatcher.dispatchRequest(request, response);

outputStream.write(response.getResponse().getBytes());
outputStream.flush();
```

---

> [의견]
HttpResponse가 직접 파일을 읽어오는 것도 좋지만 이 역할을 대신 해줄 객체가 있는 것도 좋을 것 같아요
현재는 HttpResponse가 HTTP 응답과 관련된 책임 외에도 스트림에 결과 내보내기, 파일 읽어오기 등 다양한 역할을 갖고 있는 것 같네요!

이 부분도 유틸을 만들어야하나 고민 했었는데 `HttpResponse` 외의 클래스에서는 사용될 일이 없어서 여전히 분리는 고민하고 있습니다. 클로버는 혹시 이런 경우에도 분리하는 편인가요? 🤔

---

> 여기서 만약 테스트 데이터가 바뀐다면 `Content-Length`도 바껴야 할테니 동적으로 처리되면 좋겠네요 😄

[`1d0195c`](https://github.com/woowacourse/java-http/commit/1d0195c45e6e1d6a4ed37eb1caf41a82b46a982e) 반영했습니다! 😊