### PR TITLE
[4단계 - Tomcat 구현하기] 새양(양경호) 미션 제출합니다.

### DIFF
--- a/study/src/main/resources/application.yml
+++ b/study/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 server:
   tomcat:
     accept-count: 1
-    max-connections: 1
+    max-connections: 3
     threads:
       min-spare: 2
       max: 2

--- a/study/src/test/java/thread/stage0/SynchronizationTest.java
+++ b/study/src/test/java/thread/stage0/SynchronizationTest.java
@@ -1,29 +1,24 @@
 package thread.stage0;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 /**
- * 다중 스레드 환경에서 두 개 이상의 스레드가 변경 가능한(mutable) 공유 데이터를 동시에 업데이트하면 경쟁 조건(race condition)이 발생한다.
- * 자바는 공유 데이터에 대한 스레드 접근을 동기화(synchronization)하여 경쟁 조건을 방지한다.
- * 동기화된 블록은 하나의 스레드만 접근하여 실행할 수 있다.
- *
- * Synchronization
- * https://docs.oracle.com/javase/tutorial/essential/concurrency/sync.html
+ * 다중 스레드 환경에서 두 개 이상의 스레드가 변경 가능한(mutable) 공유 데이터를 동시에 업데이트하면 경쟁 조건(race condition)이 발생한다. 자바는 공유 데이터에 대한 스레드 접근을
+ * 동기화(synchronization)하여 경쟁 조건을 방지한다. 동기화된 블록은 하나의 스레드만 접근하여 실행할 수 있다.
+ * <p>
+ * Synchronization https://docs.oracle.com/javase/tutorial/essential/concurrency/sync.html
  */
 class SynchronizationTest {
 
     /**
-     * 테스트가 성공하도록 SynchronizedMethods 클래스에 동기화를 적용해보자.
-     * synchronized 키워드에 대하여 찾아보고 적용하면 된다.
-     *
-     * Guide to the Synchronized Keyword in Java
-     * https://www.baeldung.com/java-synchronized
+     * 테스트가 성공하도록 SynchronizedMethods 클래스에 동기화를 적용해보자. synchronized 키워드에 대하여 찾아보고 적용하면 된다.
+     * <p>
+     * Guide to the Synchronized Keyword in Java https://www.baeldung.com/java-synchronized
      */
     @Test
     void testSynchronized() throws InterruptedException {
@@ -41,7 +36,7 @@ class SynchronizationTest {
 
         private int sum = 0;
 
-        public void calculate() {
+        public synchronized void calculate() {
             setSum(getSum() + 1);
         }
 

--- a/study/src/test/java/thread/stage0/ThreadPoolsTest.java
+++ b/study/src/test/java/thread/stage0/ThreadPoolsTest.java
@@ -1,23 +1,19 @@
 package thread.stage0;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadPoolExecutor;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 /**
- * 스레드 풀은 무엇이고 어떻게 동작할까?
- * 테스트를 통과시키고 왜 해당 결과가 나왔는지 생각해보자.
- *
- * Thread Pools
- * https://docs.oracle.com/javase/tutorial/essential/concurrency/pools.html
- *
- * Introduction to Thread Pools in Java
- * https://www.baeldung.com/thread-pool-java-and-guava
+ * 스레드 풀은 무엇이고 어떻게 동작할까? 테스트를 통과시키고 왜 해당 결과가 나왔는지 생각해보자.
+ * <p>
+ * Thread Pools https://docs.oracle.com/javase/tutorial/essential/concurrency/pools.html
+ * <p>
+ * Introduction to Thread Pools in Java https://www.baeldung.com/thread-pool-java-and-guava
  */
 class ThreadPoolsTest {
 
@@ -31,8 +27,8 @@ class ThreadPoolsTest {
         executor.submit(logWithSleep("hello fixed thread pools"));
 
         // 올바른 값으로 바꿔서 테스트를 통과시키자.
-        final int expectedPoolSize = 0;
-        final int expectedQueueSize = 0;
+        final int expectedPoolSize = 2;
+        final int expectedQueueSize = 1;
 
         assertThat(expectedPoolSize).isEqualTo(executor.getPoolSize());
         assertThat(expectedQueueSize).isEqualTo(executor.getQueue().size());
@@ -46,7 +42,7 @@ class ThreadPoolsTest {
         executor.submit(logWithSleep("hello cached thread pools"));
 
         // 올바른 값으로 바꿔서 테스트를 통과시키자.
-        final int expectedPoolSize = 0;
+        final int expectedPoolSize = 3;
         final int expectedQueueSize = 0;
 
         assertThat(expectedPoolSize).isEqualTo(executor.getPoolSize());

--- a/study/src/test/java/thread/stage0/ThreadTest.java
+++ b/study/src/test/java/thread/stage0/ThreadTest.java
@@ -5,24 +5,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * 자바로 동시에 여러 작업을 처리할 때 스레드를 사용한다.
- * 스레드 객체를 직접 생성하는 방법부터 알아보자.
- * 진행하면서 막히는 부분은 아래 링크를 참고해서 해결한다.
- *
- * Thread Objects
- * https://docs.oracle.com/javase/tutorial/essential/concurrency/threads.html
- *
- * Defining and Starting a Thread
- * https://docs.oracle.com/javase/tutorial/essential/concurrency/runthread.html
+ * 자바로 동시에 여러 작업을 처리할 때 스레드를 사용한다. 스레드 객체를 직접 생성하는 방법부터 알아보자. 진행하면서 막히는 부분은 아래 링크를 참고해서 해결한다.
+ * <p>
+ * Thread Objects https://docs.oracle.com/javase/tutorial/essential/concurrency/threads.html
+ * <p>
+ * Defining and Starting a Thread https://docs.oracle.com/javase/tutorial/essential/concurrency/runthread.html
  */
 class ThreadTest {
 
     private static final Logger log = LoggerFactory.getLogger(ThreadTest.class);
 
     /**
-     * 자바에서 직접 스레드를 만드는 방법은 2가지가 있다.
-     * 먼저 Thread 클래스를 상속해서 스레드로 만드는 방법을 살펴보자.
-     * 주석을 참고하여 테스트 코드를 작성하고, 테스트를 실행시켜서 메시지가 잘 나오는지 확인한다.
+     * 자바에서 직접 스레드를 만드는 방법은 2가지가 있다. 먼저 Thread 클래스를 상속해서 스레드로 만드는 방법을 살펴보자. 주석을 참고하여 테스트 코드를 작성하고, 테스트를 실행시켜서 메시지가 잘
+     * 나오는지 확인한다.
      */
     @Test
     void testExtendedThread() throws InterruptedException {
@@ -30,15 +25,14 @@ class ThreadTest {
         Thread thread = new ExtendedThread("hello thread");
 
         // 생성한 thread 객체를 시작한다.
-         thread.start();
+        thread.start();
 
         // thread의 작업이 완료될 때까지 기다린다.
-         thread.join();
+        thread.join();
     }
 
     /**
-     * Runnable 인터페이스를 사용하는 방법도 있다.
-     * 주석을 참고하여 테스트 코드를 작성하고, 테스트를 실행시켜서 메시지가 잘 나오는지 확인한다.
+     * Runnable 인터페이스를 사용하는 방법도 있다. 주석을 참고하여 테스트 코드를 작성하고, 테스트를 실행시켜서 메시지가 잘 나오는지 확인한다.
      */
     @Test
     void testRunnableThread() throws InterruptedException {
@@ -46,10 +40,10 @@ class ThreadTest {
         Thread thread = new Thread(new RunnableThread("hello thread"));
 
         // 생성한 thread 객체를 시작한다.
-         thread.start();
+        thread.start();
 
         // thread의 작업이 완료될 때까지 기다린다.
-         thread.join();
+        thread.join();
     }
 
     private static final class ExtendedThread extends Thread {
@@ -80,3 +74,4 @@ class ThreadTest {
         }
     }
 }
+

--- a/study/src/test/java/thread/stage1/UserServlet.java
+++ b/study/src/test/java/thread/stage1/UserServlet.java
@@ -7,7 +7,7 @@ public class UserServlet {
 
     private final List<User> users = new ArrayList<>();
 
-    public void service(final User user) {
+    public synchronized void service(final User user) {
         join(user);
     }
 

--- a/study/src/test/java/thread/stage1/UserServlet.java
+++ b/study/src/test/java/thread/stage1/UserServlet.java
@@ -13,6 +13,11 @@ public class UserServlet {
 
     private void join(final User user) {
         if (!users.contains(user)) {
+            try {
+                Thread.sleep(1); // Expected context switching to another thread
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
             users.add(user);
         }
     }

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -1,13 +1,16 @@
 package org.apache.catalina.connector;
 
-import org.apache.coyote.http11.Http11Processor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.apache.coyote.http11.Http11Processor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Connector implements Runnable {
 
@@ -16,7 +19,11 @@ public class Connector implements Runnable {
     private static final int DEFAULT_PORT = 8080;
     private static final int DEFAULT_ACCEPT_COUNT = 100;
 
+    private static final int DEFAULT_MIN_SPARE_COUNT = 10;
+    private static final int DEFAULT_MAX_THREAD_COUNT = 250;
+
     private final ServerSocket serverSocket;
+    private final ExecutorService executorService;
     private boolean stopped;
 
     public Connector() {
@@ -24,8 +31,15 @@ public class Connector implements Runnable {
     }
 
     public Connector(final int port, final int acceptCount) {
+        this(port, acceptCount, DEFAULT_MIN_SPARE_COUNT, DEFAULT_MAX_THREAD_COUNT);
+    }
+
+    public Connector(final int port, final int acceptCount, final int minSpareCount, final int maxThreadCount) {
         this.serverSocket = createServerSocket(port, acceptCount);
         this.stopped = false;
+        this.executorService = new ThreadPoolExecutor(minSpareCount, maxThreadCount,
+                60L, TimeUnit.SECONDS,
+                new SynchronousQueue<>());
     }
 
     private ServerSocket createServerSocket(final int port, final int acceptCount) {
@@ -67,7 +81,7 @@ public class Connector implements Runnable {
             return;
         }
         var processor = new Http11Processor(connection);
-        new Thread(processor).start();
+        executorService.execute(processor);
     }
 
     public void stop() {

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -90,6 +90,7 @@ public class Connector implements Runnable {
         stopped = true;
         try {
             serverSocket.close();
+            executorService.shutdown();
         } catch (IOException e) {
             log.error(e.getMessage(), e);
         }

--- a/tomcat/src/main/java/org/apache/catalina/session/SessionManager.java
+++ b/tomcat/src/main/java/org/apache/catalina/session/SessionManager.java
@@ -2,15 +2,15 @@ package org.apache.catalina.session;
 
 import com.techcourse.model.User;
 import jakarta.servlet.http.HttpSession;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.catalina.Manager;
 import org.apache.coyote.http11.request.HttpRequest;
 
 public class SessionManager implements Manager {
 
-    private static final Map<String, HttpSession> SESSIONS = new HashMap<>();
+    private static final Map<String, HttpSession> SESSIONS = new ConcurrentHashMap<>();
     private static final SessionManager SESSION_MANAGER = new SessionManager();
     private static final String ATTRIBUTE_USER_NAME = "user";
 

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -25,7 +25,7 @@ public class Http11Processor implements Runnable, Processor {
 
     @Override
     public void run() {
-//        log.info("connect host: {}, port: {}", connection.getInetAddress(), connection.getPort());
+        log.info("connect host: {}, port: {}", connection.getInetAddress(), connection.getPort());
         process(connection);
     }
 

--- a/tomcat/src/test/java/org/apache/catalina/connector/ConnectorTest.java
+++ b/tomcat/src/test/java/org/apache/catalina/connector/ConnectorTest.java
@@ -1,0 +1,36 @@
+package org.apache.catalina.connector;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import support.TestHttpUtils;
+
+class ConnectorTest {
+
+    @Test
+    @DisplayName("켜져있는 서버 메인 페이지를 600개 요청 해본다.")
+    void request600() throws InterruptedException {
+        // given
+        int threadCount = 600;
+        ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+        List<Future<?>> futures = new ArrayList<>();
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            futures.add(pool.submit(() -> TestHttpUtils.send("/index.html")));
+        }
+        pool.awaitTermination(10, TimeUnit.SECONDS);
+
+        long doneCount = futures.stream()
+                .filter(Future::isDone)
+                .count();
+
+        // then
+        System.out.println("doneCount = " + doneCount);
+    }
+}

--- a/tomcat/src/test/java/org/apache/catalina/connector/ConnectorTest.java
+++ b/tomcat/src/test/java/org/apache/catalina/connector/ConnectorTest.java
@@ -1,5 +1,8 @@
 package org.apache.catalina.connector;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.http.HttpResponse;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -13,24 +16,36 @@ import support.TestHttpUtils;
 class ConnectorTest {
 
     @Test
-    @DisplayName("켜져있는 서버 메인 페이지를 600개 요청 해본다.")
+    @DisplayName("켜져있는 서버 메인 페이지를 600개 요청후 성공이 스레드 개수 250과 큐 100개 합친 350인지 확인한다.")
     void request600() throws InterruptedException {
         // given
         int threadCount = 600;
+        int expectedCount = 350;
         ExecutorService pool = Executors.newFixedThreadPool(threadCount);
-        List<Future<?>> futures = new ArrayList<>();
+        List<Future<Integer>> futures = new ArrayList<>();
 
         // when
         for (int i = 0; i < threadCount; i++) {
-            futures.add(pool.submit(() -> TestHttpUtils.send("/index.html")));
+            futures.add(pool.submit(() -> {
+                HttpResponse<String> response = TestHttpUtils.send("/index.html");
+                return response.statusCode();
+            }));
         }
-        pool.awaitTermination(10, TimeUnit.SECONDS);
 
-        long doneCount = futures.stream()
-                .filter(Future::isDone)
+        pool.shutdown();
+        pool.awaitTermination(5, TimeUnit.MINUTES);
+
+        long successCount = futures.stream()
+                .filter(future -> {
+                    try {
+                        return future.get() == 200;
+                    } catch (Exception e) {
+                        return false;
+                    }
+                })
                 .count();
 
         // then
-        System.out.println("doneCount = " + doneCount);
+        assertThat(successCount).isEqualTo(expectedCount);
     }
 }

--- a/tomcat/src/test/java/support/TestHttpUtils.java
+++ b/tomcat/src/test/java/support/TestHttpUtils.java
@@ -1,0 +1,29 @@
+package support;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+public class TestHttpUtils {
+
+    private static final HttpClient httpClient = HttpClient.newBuilder()
+            .version(HttpClient.Version.HTTP_1_1)
+            .connectTimeout(Duration.ofSeconds(1))
+            .build();
+
+    public static HttpResponse<String> send(final String path) {
+        final var request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:8080" + path))
+                .timeout(Duration.ofSeconds(1))
+                .build();
+
+        try {
+            return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
냥인🐈🧍‍♀️ 안녕하세요!

이번 미션은 학습할 내용이 대부분이어서 코드보단 PR 내용에 집중하였습니다.

그간 리뷰 덕에 정말 많이 배웠네요 😀
마지막 리뷰도 잘 부탁 드립니다! 🤗

## `stage 0` `FixedThreadPool`

테스트 코드 시작 시 아래 `newFixedThreadPool` 함수를 통해 2개의 스레드를 항상 유지하며 일을 처리하는 스레드풀을 생성합니다.
``` java
final var executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(2);
```

이후 아래 코드를 통해 3번의 `logWithSleep()` 메서드를 실행합니다.
`logWithSleep()` 는 실행되면 1초를 기다린 후 입력으로 들어온 문자열을 `Logger` 로 출력하는 메서드입니다.

``` java
executor.submit(logWithSleep("hello fixed thread pools"));
executor.submit(logWithSleep("hello fixed thread pools"));
executor.submit(logWithSleep("hello fixed thread pools"));
```

학습 테스트의 목적은 위와 같이 3개의 일을 2개의 스레드가 있는 풀에 요청했을 때 `executor.getPoolSize()` 값과 `executor.getQueue().size()` 값이 얼마인지 인지하는 것입니다.

`executor.getPoolSize()` 는 스레드 풀에 현재 존재하는 워커 스레드의 개수를 의미하며 항상 2개를 유지하도록 생성하였으니 `2`가 될 것입니다.
`executor.getQueue().size()` 는 대기중인 일 개수를 의미하며 3개의 일 중 2개는 작업 중이므로 나머지 1개가 이 큐에 존재하기에 값은 `1`이 됩니다.

``` java
final int expectedPoolSize = 2;
final int expectedQueueSize = 1;
```

## `stage 0` `CachedThreadPool`

스레드 풀 동작은 위와 동일하지만 `newCachedThreadPool()` 메서드를 통해 생성할 경우 평소에는 `0` 개의 스레드가 풀에 있다가 작업이 들어오면 최대 `Integer.MAX_VALUE (2^31-1)` 개 까지 생성합니다.
또한 `keepAliveTime` 이 기본으로 `60 Sec` 이기 때문에 생성된 스레드가 작업이 끝난 후 `60` 초 동안 다른 작업을 요청이 없으면 제거되는 원리입니다.

따라서 작업 요청 전 `executor.getPoolSize()` 은 `0` 이지만 `3` 개의 작업이 요청되었으므로 최종 값은 아래와 같습니다.

``` java
final int expectedPoolSize = 3;
final int expectedQueueSize = 0;
```

## `stage 1` `synchronized`

테스트에서 2개의 작업을 동시에 수행할 때 `UserServlet.join()` 메서드 첫 줄인 `if (!users.contains(user))` 에서 유저 추가 전 검증을 하게 되는데 새로운 유저가 추가되기 전 2개의 스레드 모두가 이 `if` 문을 통과한다면 유저를 2번 추가하는 동시성 문제 `Thread Interference` 가 발생하게 됩니다.

따라서 `public void` 사이에 `public synchronized void` 를 하게되면 한 스레드가 이 메서드에 접근할 때 이미 다른 스레드가 동작 중이면 끝날 때 까지 대기하게 됩니다.

## `stage 2` `Tomcat thread pool`

요청은총 `10` 번이 이루어지며 이에 따라 서버 설정 및 서버와 클라이언트 로그가 어떻게 찍히는지 알아보았습니다.

**Tomcat** `accept-count: 1` `max-connections: 3` `threads.min-spare: 2` `threads.max: 2`
|Server|Client|
|-|-|
|[nio-8080-exec-1] http call count : `2`<br>[nio-8080-exec-2] http call count : `1`<br>[nio-8080-exec-1] http call count : `3`<br>[nio-8080-exec-2] http call count : `4`|`Thread-4` ConnectException<br>`Thread-5` ConnectException<br>`Thread-6` ConnectException<br>`Thread-7` ConnectException<br>`Thread-8` ConnectException<br>`Thread-9` ConnectException<br>`Thread-0` HttpTimeoutException: request timed out<br>`Thread-2` HttpTimeoutException: request timed out<br>`Thread-1` `Thread-3` 은 정상 응답 받음|

|Time Stamp|Content|
|-|-|
|**200** ms|**[4개의 클라이언트 요청]**<br>2개는 스레드가 `500ms` 짜리 작업 실행 `threads.max`<br>1개는 서버까지 연결 수락 `max-connections - threads.max`<br>1개는 서버 전 OS까지 연결 수락 `accept-count`|
|**500** ms|**[추가 6개 클라이언트 요청]**<br>받아줄 공간 없어서 연결 거부 `Client-side ConnectException`|
|**500 ~ 550** ms|`500ms` 짜리 작업 완료 후 정상 응답<br>완료와 동시에 서버까지 연결 수락한 1개와 OS까지 연결 수락한 1개 각각 `500ms` 짜리 작업 실행|
|**1000** ms|Client쪽에서 요청 Timeout 인 1초가 지났으므로 `HttpTimeoutException: request timed out` 발생|
|**1000 ~ 1050** ms|Client가 timeout 되어 응답을 받지 않아도 Server는 작업을 수행했으므로 스레드 `nio-8080-exec-1` 과 `nio-8080-exec-2` 에서 로그 출력|