### PR TITLE
[4단계 - Tomcat 구현하기] 재즈(함석명) 미션 제출합니다.

### DIFF
--- a/study/src/main/resources/application.yml
+++ b/study/src/main/resources/application.yml
@@ -4,7 +4,7 @@ handlebars:
 server:
   tomcat:
     accept-count: 1
-    max-connections: 1
+    max-connections: 2
     threads:
       min-spare: 2
       max: 2

--- a/study/src/test/java/thread/stage0/SynchronizationTest.java
+++ b/study/src/test/java/thread/stage0/SynchronizationTest.java
@@ -1,12 +1,11 @@
 package thread.stage0;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 /**
  * 다중 스레드 환경에서 두 개 이상의 스레드가 변경 가능한(mutable) 공유 데이터를 동시에 업데이트하면 경쟁 조건(race condition)이 발생한다.
@@ -41,7 +40,7 @@ class SynchronizationTest {
 
         private int sum = 0;
 
-        public void calculate() {
+        public synchronized void calculate() {
             setSum(getSum() + 1);
         }
 

--- a/study/src/test/java/thread/stage0/ThreadPoolsTest.java
+++ b/study/src/test/java/thread/stage0/ThreadPoolsTest.java
@@ -1,13 +1,12 @@
 package thread.stage0;
 
-import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * 스레드 풀은 무엇이고 어떻게 동작할까?
@@ -31,8 +30,8 @@ class ThreadPoolsTest {
         executor.submit(logWithSleep("hello fixed thread pools"));
 
         // 올바른 값으로 바꿔서 테스트를 통과시키자.
-        final int expectedPoolSize = 0;
-        final int expectedQueueSize = 0;
+        final int expectedPoolSize = 2;
+        final int expectedQueueSize = 1;
 
         assertThat(expectedPoolSize).isEqualTo(executor.getPoolSize());
         assertThat(expectedQueueSize).isEqualTo(executor.getQueue().size());
@@ -46,7 +45,7 @@ class ThreadPoolsTest {
         executor.submit(logWithSleep("hello cached thread pools"));
 
         // 올바른 값으로 바꿔서 테스트를 통과시키자.
-        final int expectedPoolSize = 0;
+        final int expectedPoolSize = 3;
         final int expectedQueueSize = 0;
 
         assertThat(expectedPoolSize).isEqualTo(executor.getPoolSize());

--- a/tomcat/src/main/java/com/techcourse/controller/RootController.java
+++ b/tomcat/src/main/java/com/techcourse/controller/RootController.java
@@ -15,6 +15,6 @@ public class RootController extends AbstractController {
     @Override
     protected void doGet(HttpRequest request, HttpResponse response) throws Exception {
         response.setContentType(ContentType.HTML);
-        response.write("Hello world!");
+        response.setBody("Hello world!");
     }
 }

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.apache.catalina.Mapper;
 import org.apache.coyote.http11.Http11Processor;
 import org.slf4j.Logger;
@@ -15,16 +17,19 @@ public class Connector {
 
     private static final int DEFAULT_PORT = 8080;
     private static final int DEFAULT_ACCEPT_COUNT = 100;
+    private static final int DEFAULT_MAX_THREAD_COUNT = 100;
 
     private final ServerSocket serverSocket;
+    private final ExecutorService executorService;
     private boolean stopped;
 
     public Connector() {
-        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT);
+        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT, DEFAULT_MAX_THREAD_COUNT);
     }
 
-    public Connector(final int port, final int acceptCount) {
+    public Connector(final int port, final int acceptCount, final int maxThreads) {
         this.serverSocket = createServerSocket(port, acceptCount);
+        this.executorService = Executors.newFixedThreadPool(maxThreads);
         this.stopped = false;
     }
 
@@ -66,7 +71,7 @@ public class Connector {
             return;
         }
         var processor = new Http11Processor(connection, mapper);
-        new Thread(processor).start();
+        executorService.submit(processor);
     }
 
     public void stop() {

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -17,7 +17,7 @@ public class Connector {
 
     private static final int DEFAULT_PORT = 8080;
     private static final int DEFAULT_ACCEPT_COUNT = 100;
-    private static final int DEFAULT_MAX_THREAD_COUNT = 100;
+    private static final int DEFAULT_MAX_THREAD_COUNT = 250;
 
     private final ServerSocket serverSocket;
     private final ExecutorService executorService;

--- a/tomcat/src/main/java/org/apache/catalina/startup/Tomcat.java
+++ b/tomcat/src/main/java/org/apache/catalina/startup/Tomcat.java
@@ -11,8 +11,8 @@ public class Tomcat {
     private static final Logger log = LoggerFactory.getLogger(Tomcat.class);
 
     public void start(Mapper mapper) {
-        var connector = new Connector(mapper);
-        connector.start();
+        var connector = new Connector();
+        connector.start(mapper);
 
         try {
             // make the application wait until we press any key.

--- a/tomcat/src/main/java/org/apache/coyote/AbstractController.java
+++ b/tomcat/src/main/java/org/apache/coyote/AbstractController.java
@@ -5,7 +5,7 @@ import org.apache.coyote.http11.request.HttpRequest;
 import org.apache.coyote.http11.request.startLine.HttpMethod;
 import org.apache.coyote.http11.response.HttpResponse;
 
-public class AbstractController implements Controller {
+public abstract class AbstractController implements Controller {
 
     @Override
     public final void service(HttpRequest request, HttpResponse response) throws Exception {

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -75,6 +75,10 @@ public class Http11Processor implements Runnable, Processor {
     }
 
     private Controller handleStaticRequest(HttpRequest httpRequest) {
-        return httpRequest.isStaticResource() ? new DefaultController() : new NotFoundController();
+        if (httpRequest.isStaticResource()) {
+            return new DefaultController();
+        }
+
+        return new NotFoundController();
     }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/response/HttpResponse.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/response/HttpResponse.java
@@ -28,25 +28,29 @@ public class HttpResponse {
     }
 
     public void ok(String fileName) throws IOException {
-        String content = ResourceReader.read(fileName);
-        this.statusLine = new StatusLine(HttpStatus.OK);
-        this.responseHeaders.addContentHeaders(ContentType.findByExtension(fileName), content);
-        this.responseBody = new ResponseBody(content);
+        statusLine = new StatusLine(HttpStatus.OK);
+        responseBody = new ResponseBody(ResourceReader.read(fileName));
+        responseHeaders.addHeader(HttpHeader.CONTENT_TYPE, ContentType.findByExtension(fileName).value());
+        responseHeaders.addHeader(HttpHeader.CONTENT_LENGTH, responseBody.getContentLength());
     }
 
     public void redirect(String path) {
-        this.statusLine = new StatusLine(HttpStatus.FOUND);
-        this.responseHeaders.addHeader(HttpHeader.LOCATION, path);
-        this.responseBody = new ResponseBody();
+        statusLine = new StatusLine(HttpStatus.FOUND);
+        responseHeaders.addHeader(HttpHeader.LOCATION, path);
+        responseBody = new ResponseBody();
     }
 
     public void setBody(String content) {
-        this.responseBody = new ResponseBody(content);
-        this.responseHeaders.addHeader(HttpHeader.CONTENT_LENGTH, responseBody.getContentLength());
+        responseBody = new ResponseBody(content);
+        responseHeaders.addHeader(HttpHeader.CONTENT_LENGTH, responseBody.getContentLength());
     }
 
     public void setContentType(ContentType contentType) {
         responseHeaders.addHeader(HttpHeader.CONTENT_TYPE, contentType.value());
+    }
+
+    public void addHeader(HttpHeader httpHeader, String value) {
+        responseHeaders.addHeader(httpHeader, value);
     }
 
     public void addCookie(Cookie cookie) {

--- a/tomcat/src/main/java/org/apache/coyote/http11/response/HttpResponse.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/response/HttpResponse.java
@@ -3,7 +3,6 @@ package org.apache.coyote.http11.response;
 import static org.apache.coyote.http11.Constants.CRLF;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import org.apache.coyote.http11.Cookie;
 import org.apache.coyote.http11.HttpHeader;
 import org.apache.coyote.http11.response.body.ResponseBody;
@@ -41,10 +40,9 @@ public class HttpResponse {
         this.responseBody = new ResponseBody();
     }
 
-    public void write(String content) {
-        String contentLength = Integer.toString(content.getBytes(StandardCharsets.UTF_8).length);
-        this.responseHeaders.addHeader(HttpHeader.CONTENT_LENGTH, contentLength);
+    public void setBody(String content) {
         this.responseBody = new ResponseBody(content);
+        this.responseHeaders.addHeader(HttpHeader.CONTENT_LENGTH, responseBody.getContentLength());
     }
 
     public void setContentType(ContentType contentType) {

--- a/tomcat/src/main/java/org/apache/coyote/http11/response/body/ResponseBody.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/response/body/ResponseBody.java
@@ -2,6 +2,8 @@ package org.apache.coyote.http11.response.body;
 
 import static org.apache.coyote.http11.Constants.EMPTY;
 
+import java.nio.charset.StandardCharsets;
+
 public class ResponseBody {
 
     private final String responseBody;
@@ -12,6 +14,10 @@ public class ResponseBody {
 
     public ResponseBody() {
         this.responseBody = EMPTY;
+    }
+
+    public String getContentLength() {
+        return Integer.toString(responseBody.getBytes(StandardCharsets.UTF_8).length);
     }
 
     public String toMessage() {

--- a/tomcat/src/main/java/org/apache/coyote/http11/response/header/ResponseHeaders.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/response/header/ResponseHeaders.java
@@ -3,7 +3,6 @@ package org.apache.coyote.http11.response.header;
 import static org.apache.coyote.http11.Constants.CRLF;
 import static org.apache.coyote.http11.Constants.HTTP_HEADER_SEPARATOR;
 
-import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.apache.coyote.http11.HttpHeader;
@@ -18,11 +17,6 @@ public class ResponseHeaders {
 
     public ResponseHeaders() {
         this.headers = new LinkedHashMap<>();
-    }
-
-    public void addContentHeaders(ContentType contentType, String body) {
-        headers.put(HttpHeader.CONTENT_TYPE, contentType.value());
-        headers.put(HttpHeader.CONTENT_LENGTH, Integer.toString(body.getBytes(StandardCharsets.UTF_8).length));
     }
 
     public void addHeader(HttpHeader name, String value) {

--- a/tomcat/src/test/java/org/apache/coyote/http11/response/HttpResponseTest.java
+++ b/tomcat/src/test/java/org/apache/coyote/http11/response/HttpResponseTest.java
@@ -2,6 +2,7 @@ package org.apache.coyote.http11.response;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.coyote.http11.HttpHeader;
 import org.apache.coyote.http11.response.body.ResponseBody;
 import org.apache.coyote.http11.response.header.ContentType;
 import org.apache.coyote.http11.response.header.ResponseHeaders;
@@ -17,7 +18,8 @@ class HttpResponseTest {
         String content = "TOMCAT JAZZ";
 
         ResponseHeaders responseHeaders = new ResponseHeaders();
-        responseHeaders.addContentHeaders(ContentType.HTML, content);
+        responseHeaders.addHeader(HttpHeader.CONTENT_TYPE, ContentType.HTML.value());
+        responseHeaders.addHeader(HttpHeader.CONTENT_LENGTH, "11");
 
         ResponseBody responseBody = new ResponseBody(content);
         HttpResponse httpResponse = new HttpResponse(HttpStatus.OK, responseHeaders, responseBody);

--- a/tomcat/src/test/java/org/apache/coyote/http11/response/body/ResponseBodyTest.java
+++ b/tomcat/src/test/java/org/apache/coyote/http11/response/body/ResponseBodyTest.java
@@ -1,0 +1,20 @@
+package org.apache.coyote.http11.response.body;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ResponseBodyTest {
+
+    @DisplayName("응답 바디 데이터의 바이트 길이를 계산한다.")
+    @Test
+    void getContentLengthTest() {
+        assertAll(
+                () -> assertThat(new ResponseBody("Hello world!").getContentLength()).isEqualTo("12"),
+                () -> assertThat(new ResponseBody("재즈").getContentLength()).isEqualTo("6")
+        );
+    }
+
+}


### PR DESCRIPTION
낙낙 안녕하세요~ 😀
시간이 정말 빠르네요 벌써 마지막 4단계 리뷰 요청이라니.. ㅠㅠ

이번 마지막 미션은 스레드 풀을 생성해서 매 요청마다 스레드를 무제한 생성하지 않도록 제한을 두고
동시성을 고려하여 동기화 컬렉션을 사용하는 것이 목표였어요.

기능 요구 사항이 복잡하지는 않았기에 구현은 간단하게 끝났었는데요
오늘 하루 종일 다 같이 삽질한 ㅋㅋ 스레드 풀과 acceptCount, Socket accept 에 관한 내용은 아직도 의문으로 남아있어요.

현재는 새로운 클라이언트 요청이 들어오는 시점마다 소켓의 `listen()` 함수 호출 후 백로그를 거치지 않고 바로 `accept()`가 호출되어 스레드 풀로 `submit` 되고 있는데요. 스레드 풀의 대기 큐 크기 초과 정책으로 추가 요청을 거절한다고 해도, accept() 호출 시점이 고려되지 않기 때문에 요청이 단시간에 폭발했을 시에 심각한 메모리 낭비를 유발할 것 같다는 생각이 들어요.

유휴 스레드가 생겨서 백로그로부터 사용자 요청을 처리하는 시점에 `accept()`를 처리 하도록 하는게 더 나은 방안일 것 같기도한데 아직은 정확하게 근거를 못찾겠네요. 어플리케이션의 스레드 풀이 OS 소켓 자원을 일방적으로 조절하는 방식이 가장 나은 대안인지도 의문이 들어요. 두 레벨간의 적절한 조화를 찾는 방법이 있을 것 같은데 지금 학습 단계에서는 아직까지는 어렵네요. 😅

낙낙도 여전히 같은 생각이신지 궁금하고, 혹시나 새롭게 알게된 지식이 있다면 알려주세요ㅎㅎ

마지막 리뷰도 잘 부탁드립니다 낙낙 
즐거운 추석 연휴 보내세요 !! 😁