### PR TITLE
[톰캣 구현하기 - 4단계] 페드로(류형욱) 미션 제출합니다.

### DIFF
--- a/study/src/main/resources/application.yml
+++ b/study/src/main/resources/application.yml
@@ -4,7 +4,7 @@ server:
     min-response-size: 10
   tomcat:
     accept-count: 1
-    max-connections: 1
+    max-connections: 2
     threads:
       min-spare: 2
       max: 2

--- a/study/src/test/java/thread/stage0/SynchronizationTest.java
+++ b/study/src/test/java/thread/stage0/SynchronizationTest.java
@@ -41,7 +41,7 @@ class SynchronizationTest {
 
         private int sum = 0;
 
-        public void calculate() {
+        public synchronized void calculate() {
             setSum(getSum() + 1);
         }
 

--- a/study/src/test/java/thread/stage0/ThreadPoolsTest.java
+++ b/study/src/test/java/thread/stage0/ThreadPoolsTest.java
@@ -31,8 +31,8 @@ class ThreadPoolsTest {
         executor.submit(logWithSleep("hello fixed thread pools"));
 
         // 올바른 값으로 바꿔서 테스트를 통과시키자.
-        final int expectedPoolSize = 0;
-        final int expectedQueueSize = 0;
+        final int expectedPoolSize = 2;
+        final int expectedQueueSize = 1;
 
         assertThat(expectedPoolSize).isEqualTo(executor.getPoolSize());
         assertThat(expectedQueueSize).isEqualTo(executor.getQueue().size());
@@ -46,7 +46,7 @@ class ThreadPoolsTest {
         executor.submit(logWithSleep("hello cached thread pools"));
 
         // 올바른 값으로 바꿔서 테스트를 통과시키자.
-        final int expectedPoolSize = 0;
+        final int expectedPoolSize = 3;
         final int expectedQueueSize = 0;
 
         assertThat(expectedPoolSize).isEqualTo(executor.getPoolSize());

--- a/study/src/test/java/thread/stage1/UserServlet.java
+++ b/study/src/test/java/thread/stage1/UserServlet.java
@@ -11,8 +11,14 @@ public class UserServlet {
         join(user);
     }
 
-    private void join(final User user) {
+    private synchronized void join(final User user) {
         if (!users.contains(user)) {
+            // 회원가입이 0.5초 걸린다는 가정
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
             users.add(user);
         }
     }

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -87,8 +87,10 @@ public class Connector {
             connection.close();
             log.warn("Server is busy. Rejected task. {} closed.", connection);
         }
-        log.info("{} 개의 스레드 실행 중", threadPoolExecutor.getActiveCount());
-        log.info("{} 개의 작업 대기 중", threadPoolExecutor.getQueue().size());
+        log.info(
+                "Active Thread Count: {} | Queued Task Count : {}",
+                threadPoolExecutor.getActiveCount(), threadPoolExecutor.getQueue().size()
+        );
     }
 
     public void stop() {

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -33,8 +33,8 @@ public class Http11Processor implements Runnable, Processor {
 
     @Override
     public void process(final Socket connection) {
-        try (final var inputStream = connection.getInputStream();
-             final var outputStream = connection.getOutputStream()) {
+        try (var inputStream = connection.getInputStream();
+             var outputStream = connection.getOutputStream(); connection) {
 
             HttpRequest request = HttpRequestMessageReader.read(inputStream);
             HttpResponse response = HttpResponse.ok();

--- a/tomcat/src/test/java/org/apache/catalina/connector/ConnectorTest.java
+++ b/tomcat/src/test/java/org/apache/catalina/connector/ConnectorTest.java
@@ -1,0 +1,110 @@
+package org.apache.catalina.connector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+import org.apache.catalina.connector.TestClient.ResponseType;
+import org.apache.catalina.controller.AbstractController;
+import org.apache.catalina.route.DefaultDispatcher;
+import org.apache.catalina.route.RequestMapper;
+import org.apache.catalina.route.RequestMapping;
+import org.apache.coyote.Dispatcher;
+import org.apache.coyote.http11.request.HttpRequest;
+import org.apache.coyote.http11.response.HttpResponse;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ConnectorTest {
+
+    private static final Map<ResponseType, AtomicInteger> result = Map.of(
+            ResponseType.SUCCESS, new AtomicInteger(0),
+            ResponseType.SUCCESS_QUEUED, new AtomicInteger(0),
+            ResponseType.FAILED, new AtomicInteger(0)
+    );
+
+    @Disabled("시간이 오래 소요되는 테스트")
+    @DisplayName("동시 요청 시 최대로 동시에 처리할 수 있는 요청 수와 대기 수를 제한할 수 있다.")
+    @Test
+    void concurrentRequestTest() throws InterruptedException {
+        // given
+        int acceptCount = 100;
+        int maxThreads = 250;
+        int requestCount = 500;
+        int simulatingDelay = 10000;  // 충분히 커야 스레드 생성 오버헤드로 인한 오차를 줄일 수 있음
+
+        RequestMapping requestMapping = new RequestMapper();
+        requestMapping.register(createTestController(simulatingDelay));
+        Dispatcher dispatcher = new DefaultDispatcher(requestMapping);
+        Connector connector = new Connector(8080, acceptCount, maxThreads);
+        connector.start(dispatcher);
+
+        // when
+        /*
+          0. 500개 요청
+          1. 기본 스레드 150개로 바로 150개 요청처리 (success)
+          2. 이후에 수신되는 100개는 대기 후 처리 (success_queued)
+          3. 큐가 가득 찬 이후 진입하는 100개(maxThread-150)는 추가 스레드 생성 후 처리 (success)
+          4. 나머지 150개는 요청 거절 (failed)
+          서버에서 모든 요청을 accept()까지는 해 주고 있으므로,
+          (4)는 Connection Timeout이 발생하진 않지만 서버에서 소켓을 먼저 닫아서 EOFException || SocketException 발생
+         */
+        List<Thread> threads = IntStream.range(0, requestCount)
+                .mapToObj(i -> new Thread(() -> processResponse(TestClient.send("/delay", i + 1))))
+                .toList();
+
+        int tid = 1;
+        for (Thread t : threads) {
+            Thread.sleep(10);
+            System.out.println(tid++ + " 번 요청 전송");
+            t.start();
+        }
+
+        for (Thread t : threads) {
+            t.join();
+        }
+
+        // then
+        result.forEach((key, value) -> System.out.println(key + ": " + value.get()));
+        assertAll(
+                () -> assertThat(result.get(ResponseType.SUCCESS).get()).isEqualTo(maxThreads),
+                () -> assertThat(result.get(ResponseType.SUCCESS_QUEUED).get()).isEqualTo(acceptCount),
+                () -> assertThat(result.get(ResponseType.FAILED).get()).isEqualTo(
+                        requestCount - (maxThreads + acceptCount))
+        );
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private AbstractController createTestController(long delayInMillis) {
+        return new AbstractController() {
+            @Override
+            public String matchedPath() {
+                return "/delay";
+            }
+
+            @Override
+            @SuppressWarnings("CallToPrintStackTrace")
+            public void doGet(HttpRequest request, HttpResponse response) {
+                try {
+                    String tid = request.getHeaders().get("id");
+                    System.out.println(tid + " 번 요청 처리 시작");
+                    Thread.sleep(delayInMillis);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        };
+    }
+
+    private static void processResponse(SimpleEntry<ResponseType, java.net.http.HttpResponse<String>> response) {
+        if (response == null) {
+            return;
+        }
+        result.get(response.getKey()).incrementAndGet();
+    }
+}

--- a/tomcat/src/test/java/org/apache/catalina/connector/TestClient.java
+++ b/tomcat/src/test/java/org/apache/catalina/connector/TestClient.java
@@ -1,0 +1,75 @@
+package org.apache.catalina.connector;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.net.SocketException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.net.http.HttpTimeoutException;
+import java.time.Duration;
+import java.util.AbstractMap.SimpleEntry;
+
+public class TestClient {
+
+    private static final int QUEUED_THRESHOLD = 15000;
+
+    private static final HttpClient httpClient = HttpClient.newBuilder()
+            .version(HttpClient.Version.HTTP_1_1)
+            .connectTimeout(Duration.ofSeconds(5))  // Connection timeout
+            .build();
+
+    public static SimpleEntry<ResponseType, HttpResponse<String>> send(String path, int id) {
+        final var request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:8080" + path))
+                .header("id", String.valueOf(id))
+                .timeout(Duration.ofSeconds(30))  // Read timeout
+                .build();
+
+        try {
+            long start = System.currentTimeMillis();
+            HttpResponse<String> response = httpClient.send(request, BodyHandlers.ofString());
+            long elapsed = System.currentTimeMillis() - start;
+            if (response.statusCode() == 200) {
+                ResponseType responseType = ResponseType.of(response, elapsed);
+                return new SimpleEntry<>(responseType, response);
+            }
+        } catch (HttpTimeoutException e) {  // read timeout
+            return new SimpleEntry<>(ResponseType.FAILED, null);
+        } catch (IOException | InterruptedException e) {
+            if (isRequestRefused(e)) {
+                return new SimpleEntry<>(ResponseType.FAILED, null);
+            }
+            throw new RuntimeException(e);
+        }
+        return null;
+    }
+
+    private static boolean isRequestRefused(Throwable cause) {
+        Throwable rootCause = getRootCause(cause);
+        return rootCause instanceof SocketException || rootCause instanceof EOFException;
+    }
+
+    private static Throwable getRootCause(Throwable e) {
+        Throwable cause;
+        Throwable result = e;
+
+        while (null != (cause = result.getCause()) && (result != cause)) {
+            result = cause;
+        }
+        return result;
+    }
+
+    public enum ResponseType {
+        SUCCESS, SUCCESS_QUEUED, FAILED;
+
+        public static ResponseType of(HttpResponse<String> response, long elapsed) {
+            if (response == null || response.statusCode() != 200) {
+                return FAILED;
+            }
+            return elapsed >= QUEUED_THRESHOLD ? SUCCESS_QUEUED : SUCCESS;
+        }
+    }
+}


### PR DESCRIPTION
허허... 브랜치 꼬인 걸 해결하다가 PR 작성했던 브랜치를 삭제해 버려서 PR이 닫혀버렸네요..
다시 요청 드립니다😅

---

이번 단계 진행 중 생긴 의문들을 정리해서 슬랙에 공유했었는데, 기록 차 PR 본문에도 남겨 둡니다ㅎㅎ
재즈도 아까 저랑 같이 고민했었으니 혹시 알게 된 것이 있다면 공유해 주세요🔥

(아래는 원문입니다.)

톰캣 4단계 미션 진행 중 궁금한 사항이 생겨 질문 남깁니다.

1. ServerSocket은 accept() 후 클라이언트와 연결이 수립된 Socket 객체를 반환합니다. 이 인스턴스 역시 AutoClosable인데 Http11Processor.process() 의 try with resource 구문에 빠져 있는 이유가 뭘까요? 소켓을 닫아주지 않아도 되는 걸까요?

2. POSIX 소켓은 socket() -> bind() -> listen() -> accept() -> [ 통신 ] -> close() 의 플로우를 가집니다.
클라이언트의 connect() 요청 시(SYN) 서버는 STN+ACK를 응답, 3-way handshaking 과정을 거치면서 서버-클라이언트 측 소켓이 ESTABLISHED 상태가 됩니다.

이때, 서버가 다른 요청을 처리하느라 바빠 ESTABLISHED 상태에 놓인 소켓을 accept() 해 주지 못한다면, 해당 요청들은 Accept큐(Backlog)에 남아 대기합니다.

ServerSocket의 생성자 두 번째 인자로 이 Accept 큐의 크기를 전달하여 소켓을 생성할 수 있는데요, 지정하지 않는다면 기본값으로 50이 사용됩니다. (리눅스 표준은 4096으로 알고 있는데 자바 자체의 기본값인 것 같아요)

이번 미션에서 제공되었던 코드는 백로그 값이 상수 `DEFAULT_ACCEPT_COUNT=100` 으로 설정되어 있었는데, **"ACCEPT_COUNT" 라는 변수명이 의미를 가지려면 요청이 오는 대로 전부 accept() 해 버리면 안 될 것 같다고 생각했어요.** 바로바로 accept()되면 backlog queue에 대기하는 있는 요청이 없어지고, 결국 서버의 메모리에는 요청 한 건 당 하나의 `Socket`이 생길 것 같아요.

위와 같은 이유 때문에, 4단계에서 스레드 풀을 적용하면서 풀의 크기를 제한하고, 스레드 내부에서 `accept()`를 수행해야 하나 고민이 들었습니다. 다른 분들은 어떻게 구현하셨나요?

backlog 값은 시스템 콜 `int listen(int sockfd, int backlog);` 으로 전달될 텐데, OS나 커널 구현에 따라 해당 값을 완전히 무시하거나 정확하게 따르지 않는 경우도 있어서 애초에 ACCEPT COUNT를 백로그 값으로 전달하는게 크게 의미가 있나 싶기도 했어요. 이름은 backlog queue지만, FIFO가 보장되지 않아서 사용자 요청 큐잉에 사용해도 되나?의 의문도 남았구요.


