### PR TITLE
[1단계 - HTTP 서버 구현하기] 대니(정구홍) 미션 제출합니다 

### DIFF
--- a/.github/workflows/code-quality-review.yml
+++ b/.github/workflows/code-quality-review.yml
@@ -1,7 +1,7 @@
 name: Code Quality Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
   issue_comment:
     types: [created]
@@ -10,7 +10,7 @@ jobs:
   claude-review:
     # Run on PR events, or when someone comments "@claude review" on a PR
     if: |
-      github.event_name == 'pull_request' ||
+      github.event_name == 'pull_request_target' ||
       (github.event_name == 'issue_comment' && 
        github.event.issue.pull_request && 
        contains(github.event.comment.body, '@claude review'))
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
       id-token: write
@@ -27,6 +27,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 
       - name: Generate GitHub App token

--- a/.github/workflows/step1-code-review.yml
+++ b/.github/workflows/step1-code-review.yml
@@ -1,7 +1,7 @@
 name: Step1 Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
   issue_comment:
     types: [created]
@@ -9,7 +9,7 @@ on:
 jobs:
   claude-review:
     if: |
-      (github.event_name == 'pull_request' && (
+      (github.event_name == 'pull_request_target' && (
         contains(github.event.pull_request.title, 'step1') ||
         contains(github.event.pull_request.title, 'Step1') ||
         contains(github.event.pull_request.title, '1단계') ||
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
       id-token: write
@@ -31,6 +31,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 
       - name: Generate GitHub App token

--- a/.github/workflows/step2-code-review.yml
+++ b/.github/workflows/step2-code-review.yml
@@ -1,7 +1,7 @@
 name: Step2 Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
   issue_comment:
     types: [created]
@@ -9,7 +9,7 @@ on:
 jobs:
   claude-review:
     if: |
-      (github.event_name == 'pull_request' && (
+      (github.event_name == 'pull_request_target' && (
         contains(github.event.pull_request.title, 'step2') ||
         contains(github.event.pull_request.title, 'Step2') ||
         contains(github.event.pull_request.title, '2단계') ||
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
       id-token: write
@@ -31,6 +31,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 
       - name: Generate GitHub App token

--- a/.github/workflows/step3-code-review.yml
+++ b/.github/workflows/step3-code-review.yml
@@ -1,7 +1,7 @@
 name: Step3 Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
   issue_comment:
     types: [created]
@@ -9,7 +9,7 @@ on:
 jobs:
   claude-review:
     if: |
-      (github.event_name == 'pull_request' && (
+      (github.event_name == 'pull_request_target' && (
         contains(github.event.pull_request.title, 'step3') ||
         contains(github.event.pull_request.title, 'Step3') ||
         contains(github.event.pull_request.title, '3단계') ||
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
       id-token: write
@@ -31,6 +31,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 
       - name: Generate GitHub App token

--- a/.github/workflows/step4-code-review.yml
+++ b/.github/workflows/step4-code-review.yml
@@ -1,7 +1,7 @@
 name: Step4 Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
   issue_comment:
     types: [created]
@@ -9,7 +9,7 @@ on:
 jobs:
   claude-review:
     if: |
-      (github.event_name == 'pull_request' && (
+      (github.event_name == 'pull_request_target' && (
         contains(github.event.pull_request.title, 'step4') ||
         contains(github.event.pull_request.title, 'Step4') ||
         contains(github.event.pull_request.title, '4단계') ||
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
       id-token: write
@@ -31,6 +31,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 
       - name: Generate GitHub App token

--- a/study/build.gradle
+++ b/study/build.gradle
@@ -24,10 +24,6 @@ dependencies {
     implementation 'com.github.jknack:handlebars-springmvc:4.4.0'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
-    testImplementation 'org.mockito:mockito-core:5.18.0'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.13.3'
-    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.13.3'
 }
 
 test {

--- a/tomcat/build.gradle
+++ b/tomcat/build.gradle
@@ -20,8 +20,8 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'org.mockito:mockito-core:5.18.0'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.13.3'
-    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.13.3'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
 }
 
 test {

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -1,15 +1,19 @@
 package org.apache.coyote.http11;
 
+import com.techcourse.db.InMemoryUserRepository;
 import com.techcourse.exception.UncheckedServletException;
+import com.techcourse.model.User;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.Socket;
+import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.coyote.Processor;
@@ -35,51 +39,109 @@ public class Http11Processor implements Runnable, Processor {
     @Override
     public void process(final Socket connection) {
         try (final var inputStream = connection.getInputStream();
+             final var inputStreamReader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
+             final var bufferedReader = new BufferedReader(inputStreamReader);
              final var outputStream = connection.getOutputStream()) {
 
-            byte[] responseBodyBytes = "Hello world!".getBytes();
-
-            InputStreamReader inputStreamReader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
-            BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
             String requestLine = bufferedReader.readLine();
-            String requestURI = requestLine.split(" ")[1];
-
-            Map<String, String> requestHeaders = new HashMap<>();
-            while (true) {
-                String line = bufferedReader.readLine();
-                if (line == null || line.isEmpty()) {
-                    break;
-                }
-                String headerName = line.split(": ")[0];
-                String headerContent = line.split(": ")[1];
-                requestHeaders.put(headerName, headerContent);
+            if (requestLine == null) {
+                return;
             }
-            String contentType = "text/html;charset=utf-8 ";
+            String fullRequestURI = requestLine.split(" ")[1];
 
-            if (requestHeaders.get("Accept") != null) {
-                String acceptHeaderContent = requestHeaders.get("Accept");
-                String[] acceptHeaders = acceptHeaderContent.split(",");
-                if (Arrays.asList(acceptHeaders).contains("text/css")) {
+            URI uri = new URI(fullRequestURI);
+            String requestPath = uri.getPath();
+            String query = uri.getQuery();
+
+            Map<String, String> queryParams = parseQueryParams(query);
+            Map<String, String> requestHeaders = parseRequestHeaders(bufferedReader);
+
+            byte[] responseBodyBytes = null;
+            String contentType = "text/html;charset=utf-8";
+            String statusCode = "200 OK";
+
+            if ("/".equals(requestPath)) {
+                responseBodyBytes = "Hello world!".getBytes(StandardCharsets.UTF_8);
+            } else if ("/login".equals(requestPath) && queryParams.containsKey("account")) {
+                User user = InMemoryUserRepository.findByAccount(queryParams.get("account"))
+                        .orElseThrow(() -> new IllegalArgumentException("입력된 값과 일치하는 user가 존재하지 않습니다."));
+                if (!user.checkPassword(queryParams.get("password"))) {
+                    throw new IllegalArgumentException("입력된 password가 등록된 값과 일치하지 않습니다.");
+                }
+
+                log.atInfo().log("user: {}", user.toString());
+            }
+
+            String resourcePath;
+            if ("/login".equals(requestPath)) {
+                resourcePath = "static/login.html";
+            } else {
+                resourcePath = "static" + requestPath;
+            }
+
+            URL resource = ClassLoader.getSystemResource(resourcePath);
+            if (resource != null) {
+                responseBodyBytes = Files.readAllBytes(Path.of(resource.toURI()));
+                if (resourcePath.endsWith(".css")) {
                     contentType = "text/css";
                 }
             }
 
-            if (!"/".equals(requestURI)) {
-                Path path = Path.of(ClassLoader.getSystemResource("static" + requestURI).toURI());
-                responseBodyBytes = Files.readAllBytes(path);
+            if (responseBodyBytes == null) {
+                statusCode = "404 Not Found";
+                URL resource404 = ClassLoader.getSystemResource("static/404.html");
+                if (resource404 != null) {
+                    responseBodyBytes = Files.readAllBytes(Path.of(resource404.toURI()));
+                } else {
+                    responseBodyBytes = "404 Not Found".getBytes(StandardCharsets.UTF_8);
+                }
             }
 
-            var responseHeaders = String.join("\r\n",
-                    "HTTP/1.1 200 OK ",
+            String responseHeaders = String.join(" \r\n",
+                    "HTTP/1.1 " + statusCode,
                     "Content-Type: " + contentType,
-                    "Content-Length: " + responseBodyBytes.length + " ",
+                    "Content-Length: " + responseBodyBytes.length,
                     "\r\n");
 
-            outputStream.write(responseHeaders.getBytes());
+            outputStream.write(responseHeaders.getBytes(StandardCharsets.UTF_8));
             outputStream.write(responseBodyBytes);
             outputStream.flush();
+
         } catch (IOException | UncheckedServletException | URISyntaxException e) {
             log.error(e.getMessage(), e);
+        } catch (IllegalArgumentException e) {
+            log.warn(e.getMessage());
         }
+    }
+
+    private Map<String, String> parseQueryParams(String query) {
+        Map<String, String> queryParams = new HashMap<>();
+        if (query != null && !query.isEmpty()) {
+            String[] pairs = query.split("&");
+            for (String pair : pairs) {
+                String[] keyValue = pair.split("=", 2);
+                if (keyValue.length == 2) {
+                    String key = URLDecoder.decode(keyValue[0], StandardCharsets.UTF_8);
+                    String value = URLDecoder.decode(keyValue[1], StandardCharsets.UTF_8);
+                    queryParams.put(key, value);
+                }
+            }
+        }
+        return queryParams;
+    }
+
+    private Map<String, String> parseRequestHeaders(BufferedReader bufferedReader) throws IOException {
+        Map<String, String> requestHeaders = new HashMap<>();
+        while (true) {
+            String line = bufferedReader.readLine();
+            if (line == null || line.isEmpty()) {
+                break;
+            }
+            String[] headerParts = line.split(": ", 2);
+            if (headerParts.length == 2) {
+                requestHeaders.put(headerParts[0], headerParts[1]);
+            }
+        }
+        return requestHeaders;
     }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -68,22 +68,22 @@ public class Http11Processor implements Runnable, Processor {
                 if (!user.checkPassword(queryParams.get("password"))) {
                     throw new IllegalArgumentException("입력된 password가 등록된 값과 일치하지 않습니다.");
                 }
-
+                responseBodyBytes = "로그인 성공".getBytes();
                 log.atInfo().log("user: {}", user.toString());
-            }
-
-            String resourcePath;
-            if ("/login".equals(requestPath)) {
-                resourcePath = "static/login.html";
             } else {
-                resourcePath = "static" + requestPath;
-            }
+                String resourcePath;
+                if ("/login".equals(requestPath)) {
+                    resourcePath = "static/login.html";
+                } else {
+                    resourcePath = "static" + requestPath;
+                }
 
-            URL resource = ClassLoader.getSystemResource(resourcePath);
-            if (resource != null) {
-                responseBodyBytes = Files.readAllBytes(Path.of(resource.toURI()));
-                if (resourcePath.endsWith(".css")) {
-                    contentType = "text/css";
+                URL resource = ClassLoader.getSystemResource(resourcePath);
+                if (resource != null) {
+                    responseBodyBytes = Files.readAllBytes(Path.of(resource.toURI()));
+                    if (resourcePath.endsWith(".css")) {
+                        contentType = "text/css";
+                    }
                 }
             }
 
@@ -108,9 +108,9 @@ public class Http11Processor implements Runnable, Processor {
             outputStream.flush();
 
         } catch (IOException | UncheckedServletException | URISyntaxException e) {
-            log.error(e.getMessage(), e);
+            log.atError().log(e.getMessage(), e);
         } catch (IllegalArgumentException e) {
-            log.warn(e.getMessage());
+            log.atWarn().log(e.getMessage());
         }
     }
 

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -78,7 +78,7 @@ public class Http11Processor implements Runnable, Processor {
                     resourcePath = "static" + requestPath;
                 }
 
-                URL resource = ClassLoader.getSystemResource(resourcePath);
+                URL resource = getClass().getClassLoader().getResource(resourcePath);
                 if (resource != null) {
                     responseBodyBytes = Files.readAllBytes(Path.of(resource.toURI()));
                     if (resourcePath.endsWith(".css")) {
@@ -89,7 +89,7 @@ public class Http11Processor implements Runnable, Processor {
 
             if (responseBodyBytes == null) {
                 statusCode = "404 Not Found";
-                URL resource404 = ClassLoader.getSystemResource("static/404.html");
+                URL resource404 = getClass().getClassLoader().getResource("static/404.html");
                 if (resource404 != null) {
                     responseBodyBytes = Files.readAllBytes(Path.of(resource404.toURI()));
                 } else {


### PR DESCRIPTION
# 기능 구현: HTTP 요청에 따른 정적 파일 응답 기능 추가

안녕하세요 듀이~
HTTP에 대해 학습한 내용을 바탕으로, 기본적인 웹서버의 요청 처리 기능을 구현해보았습니다.

HTTP 요청을 받고 파싱하여 적절한 정적 파일을 찾아 응답하는 `Http11Processor`를 추가했습니다. 학습과 구현을 병행하다 보니 코드를 더 깔끔하게 다듬는 데는 부족함이 있을 수 있지만, 우선 핵심 기능의 동작에 집중했습니다.

부족한 부분이 많겠지만, 잘 부탁드립니다! 😄

### 주요 작업 내용
- **HTTP 요청 처리 로직 구현**
  - 소켓으로 들어온 요청의 첫 줄(Request Line)을 읽어 요청 URI를 파싱합니다.
  - URI가 `/`인 경우, 기본 페이지(`Hello world!`)를 응답합니다.
  - 그 외의 경로일 경우, `resources/static` 디렉터리 내의 해당 파일을 찾아 응답합니다.

- **`Content-Type` 헤더 동적 설정**
  - 요청된 파일의 확장자를 분석하여 `text/html`, `text/css` 등 적절한 `Content-Type`을 응답 헤더에 설정하도록 구현했습니다.

- **기타**
  - HTTP 요청 헤더를 파싱하는 로직을 추가했지만, 현재 응답 로직에는 직접적으로 사용되지는 않습니다.
  - (TMI) 처음에는 `Accept` 헤더를 기준으로 `Content-Type`을 분기하려다, 우선은 확장자 기반으로 단순화하여 구현 방향을 변경했습니다.