### PR TITLE
[3단계 - 리팩터링] 제프리(홍성호) 미션 제출합니다.

### DIFF
--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Cookie.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Cookie.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 public class Http11Cookie {
 
-    private Map<String, String> cookies = new HashMap<>();
+    private final Map<String, String> cookies;
 
     public Http11Cookie(String cookieHeader) {
         Map<String, String> cookies = new HashMap<>();
@@ -25,17 +25,13 @@ public class Http11Cookie {
         this.cookies = cookies;
     }
 
-    public boolean isContainsSessionId() {
-        return cookies.containsKey("JSESSIONID");
+    public boolean containsKey(String key) {
+        return cookies.containsKey(key);
     }
 
-    public boolean isNotContainsSessionId() {
-        return !isContainsSessionId();
-    }
-
-    public String getSessionId() {
-        if (isContainsSessionId()) {
-            return cookies.get("JSESSIONID");
+    public String get(String key) {
+        if (containsKey(key)) {
+            return cookies.get(key);
         } else  {
             return null;
         }

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Method.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Method.java
@@ -1,0 +1,30 @@
+package org.apache.coyote.http11;
+
+import java.util.Arrays;
+
+public enum Http11Method {
+    GET("GET"),
+    POST("POST"),
+    PUT("PUT"),
+    PATCH("PATCH"),
+    DELETE("DELETE"),
+    HEAD("HEAD"),
+    OPTIONS("OPTIONS"),;
+
+    private final String method;
+
+    Http11Method(String method) {
+        this.method = method;
+    }
+
+    public static Http11Method from(String method) throws Http11ParseException{
+        return Arrays.stream(Http11Method.values())
+                .filter(m -> m.name().equalsIgnoreCase(method))
+                .findFirst()
+                .orElseThrow(() -> new Http11ParseException(ParseError.INVALID_HTTP_METHOD));
+    }
+
+    public String getMethod() {
+        return method;
+    }
+}

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Method.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Method.java
@@ -1,6 +1,8 @@
 package org.apache.coyote.http11;
 
 import java.util.Arrays;
+import org.apache.coyote.http11.exception.Http11ParseException;
+import org.apache.coyote.http11.exception.ParseError;
 
 public enum Http11Method {
     GET("GET"),
@@ -17,7 +19,7 @@ public enum Http11Method {
         this.method = method;
     }
 
-    public static Http11Method from(String method) throws Http11ParseException{
+    public static Http11Method from(String method) throws Http11ParseException {
         return Arrays.stream(Http11Method.values())
                 .filter(m -> m.name().equalsIgnoreCase(method))
                 .findFirst()

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -1,16 +1,10 @@
 package org.apache.coyote.http11;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
-import java.util.AbstractMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Map.Entry;
 import org.apache.coyote.Processor;
 import org.apache.coyote.http11.controller.Controller;
 import org.apache.coyote.http11.controller.util.ControllerMapper;
@@ -39,87 +33,21 @@ public class Http11Processor implements Runnable, Processor {
     public void process(final Socket connection) {
         try (final var inputStream = connection.getInputStream();
              final var outputStream = connection.getOutputStream()) {
-
-            final Http11Request request;
-            try {
-                request = new Http11Request(inputStream);
-            } catch (Http11ParseException e) {
-                sendErrorResponse(outputStream);
-                return;
-            }
-            final Http11Response response = new Http11Response();
-
-            final String path = request.getPath();
-            final Http11Method method = request.getMethod();
+            final Http11Request request = new Http11Request(inputStream);
+            final Http11Response response = new Http11Response(outputStream);
 
             final Controller controller = ControllerMapper.getController(request.getPath());
             controller.service(request, response);
 
-            response.putStatusLine("HTTP/1.1 200 OK");
-            response.putBody("Hello world!");
-
-            final Map<String, String> responseHeaders = new LinkedHashMap<>();
-            responseHeaders.put("Content-Type", MediaType.detectMimeType(path));
-            response.putHeaders(responseHeaders);
-
             outputStream.write(response.buildResponse(StandardCharsets.UTF_8));
             outputStream.flush();
+            response.sendError();
         } catch (IOException e) {
             log.error(e.getMessage(), e);
         } catch (Http11ParseException ex) {
-            log.error(ex.getMessage(), ex);
+            log.error(ex.getMessage(), ex); // TODO: response.sendError()로 변경
         } catch (Exception e) {
             throw new RuntimeException(e);
-        }
-    }
-
-    private void sendErrorResponse(OutputStream outputStream)
-            throws IOException {
-        String statusLine = "HTTP/1.1 400 Bad Request"; // TODO: 별도의 핸들러로 관리
-        String responseBody = readFileFromClasspath("static/400.html");
-        final Map<String, String> responseHeaders = new LinkedHashMap<>();
-        responseHeaders.put("Content-Type", MediaType.HTML.getMimeType());
-        responseHeaders.put("Content-Length", String.valueOf(responseBody.getBytes(StandardCharsets.UTF_8).length));
-        final String response = buildResponse(statusLine, responseHeaders, responseBody);
-
-        outputStream.write(response.getBytes(StandardCharsets.UTF_8));
-        outputStream.flush();
-    }
-
-    private String readFileFromClasspath(String resourcePath) {
-        final InputStream input = getClass().getClassLoader().getResourceAsStream(resourcePath);
-        if (input == null) {
-            log.error("resource not found: {}", resourcePath);
-            return "";
-        }
-        final StringBuilder fileContents = new StringBuilder();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(input))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                fileContents.append(line).append(CRLF);
-            }
-        } catch (IOException e) {
-            log.error("Failed to read file: {}", resourcePath, e);
-            return "";
-        }
-        return fileContents.toString();
-    }
-
-    private String buildResponse(String statusLine, Map<String, String> responseHeaders, String responseBody) {
-        final StringBuilder responseBuilder = new StringBuilder();
-        responseBuilder.append(statusLine).append(CRLF);
-        appendResponseHeaders(responseHeaders, responseBuilder);
-        responseBuilder.append(CRLF);
-        responseBuilder.append(responseBody);
-        return responseBuilder.toString();
-    }
-
-    private void appendResponseHeaders(Map<String, String> responseHeaders, StringBuilder responseBuilder) {
-        for (Entry<String, String> entry : responseHeaders.entrySet()) {
-            responseBuilder.append(entry.getKey())
-                    .append(": ")
-                    .append(entry.getValue())
-                    .append(CRLF);
         }
     }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
 import org.apache.coyote.Processor;
+import org.apache.coyote.http11.exception.Http11ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -18,6 +18,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
 import org.apache.coyote.Processor;
+import org.apache.coyote.http11.controller.Controller;
+import org.apache.coyote.http11.controller.util.ControllerMapper;
 import org.apache.coyote.http11.exception.Http11ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,6 +58,9 @@ public class Http11Processor implements Runnable, Processor {
             final String path = request.getPath();
             final Http11Method method = request.getMethod();
 
+            final Controller controller = ControllerMapper.getController(request.getPath());
+            controller.service(request, response);
+
             String statusLine = "HTTP/1.1 200 OK";
             String responseBody = "Hello world!";
             final Map<String, String> responseHeaders = new LinkedHashMap<>();
@@ -84,6 +89,8 @@ public class Http11Processor implements Runnable, Processor {
             log.error(e.getMessage(), e);
         } catch (Http11ParseException ex) {
             log.error(ex.getMessage(), ex);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -2,18 +2,15 @@ package org.apache.coyote.http11;
 
 import java.io.IOException;
 import java.net.Socket;
-import java.nio.charset.StandardCharsets;
 import org.apache.coyote.Processor;
 import org.apache.coyote.http11.controller.Controller;
 import org.apache.coyote.http11.controller.util.ControllerMapper;
-import org.apache.coyote.http11.exception.Http11ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class Http11Processor implements Runnable, Processor {
 
     private static final Logger log = LoggerFactory.getLogger(Http11Processor.class);
-    private static final String CRLF = "\r\n";
 
     private final Socket connection;
 
@@ -36,13 +33,9 @@ public class Http11Processor implements Runnable, Processor {
 
             final Controller controller = ControllerMapper.getController(request.getPath());
             controller.service(request, response);
-
-            outputStream.write(response.buildResponse(StandardCharsets.UTF_8));
-            outputStream.flush();
+            response.send();
         } catch (IOException e) {
             log.error(e.getMessage(), e);
-        } catch (Http11ParseException ex) {
-            log.error(ex.getMessage(), ex); // TODO: response.sendError()로 변경
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -1,22 +1,16 @@
 package org.apache.coyote.http11;
 
-import com.techcourse.db.InMemoryUserRepository;
-import com.techcourse.model.User;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.Socket;
-import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.AbstractMap;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.UUID;
 import org.apache.coyote.Processor;
 import org.apache.coyote.http11.controller.Controller;
 import org.apache.coyote.http11.controller.util.ControllerMapper;
@@ -66,10 +60,7 @@ public class Http11Processor implements Runnable, Processor {
             final Map<String, String> responseHeaders = new LinkedHashMap<>();
             responseHeaders.put("Content-Type", MediaType.detectMimeType(path));
 
-            if ("/logout".equals(path)) {
-                statusLine = handleLogout(request, responseHeaders);
-                responseBody = "";
-            } else if (Http11Method.GET.equals(method)) {
+            if (Http11Method.GET.equals(method)) {
                 Entry<String, String> getResult = handleGetRequest(path, request, responseHeaders);
                 statusLine = getResult.getKey();
                 responseBody = getResult.getValue();
@@ -105,16 +96,6 @@ public class Http11Processor implements Runnable, Processor {
 
         outputStream.write(response.getBytes(StandardCharsets.UTF_8));
         outputStream.flush();
-    }
-
-    private String handleLogout(final Http11Request request, final Map<String, String> responseHeaders) {
-        final Http11Cookie cookie = request.getCookie();
-        if (cookie.isContainsSessionId()) {
-            SessionManager.getInstance().remove(cookie.getSessionId());
-        }
-        responseHeaders.put("Location", "/index.html");
-        responseHeaders.put("Set-Cookie", "JSESSIONID=; Path=/; Max-Age=0");
-        return "HTTP/1.1 302 Found";
     }
 
     private Entry<String, String> handleGetRequest(final String path, final Http11Request request, 

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -53,7 +53,7 @@ public class Http11Processor implements Runnable, Processor {
             }
             final Http11Response response = new Http11Response();
 
-            final String path = extractPath(request.getUri());
+            final String path = request.getPath();
             final Http11Method method = request.getMethod();
 
             String statusLine = "HTTP/1.1 200 OK";
@@ -184,16 +184,6 @@ public class Http11Processor implements Runnable, Processor {
             // TODO: CookieSecurityConfig를 통한 HttpOnly 기본, Secure/SameSite 설정 전략 등 고려하기
             responseHeaders.put("Set-Cookie", "JSESSIONID=" + sessionId + "; Path=/");
         }
-    }
-
-    private String extractPath(final String uri) {
-        if (uri == null || uri.isEmpty()) {
-            return "/";
-        }
-        if (uri.contains("?")) {
-            return uri.substring(0, uri.indexOf("?"));
-        }
-        return uri;
     }
 
     private Map<String, String> parseRequestBody(final String requestBody) {

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -55,24 +55,12 @@ public class Http11Processor implements Runnable, Processor {
             final Controller controller = ControllerMapper.getController(request.getPath());
             controller.service(request, response);
 
-            String statusLine = "HTTP/1.1 200 OK";
-            String responseBody = "Hello world!";
+            response.putStatusLine("HTTP/1.1 200 OK");
+            response.putBody("Hello world!");
+
             final Map<String, String> responseHeaders = new LinkedHashMap<>();
             responseHeaders.put("Content-Type", MediaType.detectMimeType(path));
-
-            if (Http11Method.GET.equals(method)) {
-                Entry<String, String> getResult = handleGetRequest(path, request, responseHeaders);
-                statusLine = getResult.getKey();
-                responseBody = getResult.getValue();
-            } else if (Http11Method.POST.equals(method)) {
-                statusLine = handlePostRequest(path, request, responseHeaders);
-                responseBody = "";
-            }
-
-            responseHeaders.put("Content-Length", String.valueOf(responseBody.getBytes(StandardCharsets.UTF_8).length));
-            response.putStatusLine(statusLine);
             response.putHeaders(responseHeaders);
-            response.putBody(responseBody);
 
             outputStream.write(response.buildResponse(StandardCharsets.UTF_8));
             outputStream.flush();
@@ -96,30 +84,6 @@ public class Http11Processor implements Runnable, Processor {
 
         outputStream.write(response.getBytes(StandardCharsets.UTF_8));
         outputStream.flush();
-    }
-
-    private Entry<String, String> handleGetRequest(final String path, final Http11Request request, 
-                                                   final Map<String, String> responseHeaders) {
-        String statusLine = "HTTP/1.1 200 OK";
-        String responseBody;
-
-        if (!"/".equals(path)) {
-            responseBody = readFileFromClasspath("static" + path);
-            if (responseBody.isEmpty()) {
-                statusLine = "HTTP/1.1 404 Not Found";
-                responseBody = readFileFromClasspath("static/404.html");
-            }
-        } else {
-            responseBody = "Hello world!";
-        }
-
-        return new AbstractMap.SimpleEntry<>(statusLine, responseBody);
-    }
-
-    private String handlePostRequest(final String path, final Http11Request request, 
-                                     final Map<String, String> responseHeaders) {
-        Map<String, String> params = request.getParams();
-        return "HTTP/1.1 404 Not Found";
     }
 
     private String readFileFromClasspath(String resourcePath) {

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -1,8 +1,6 @@
 package org.apache.coyote.http11;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import org.apache.coyote.Processor;
@@ -41,7 +39,6 @@ public class Http11Processor implements Runnable, Processor {
 
             outputStream.write(response.buildResponse(StandardCharsets.UTF_8));
             outputStream.flush();
-            response.sendError();
         } catch (IOException e) {
             log.error(e.getMessage(), e);
         } catch (Http11ParseException ex) {

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -52,7 +52,7 @@ public class Http11Processor implements Runnable, Processor {
             }
 
             final String path = extractPath(request.getUri());
-            final String method = request.getMethod();
+            final Http11Method method = request.getMethod();
 
             String statusLine = "HTTP/1.1 200 OK";
             String responseBody = "Hello world!";
@@ -62,11 +62,11 @@ public class Http11Processor implements Runnable, Processor {
             if ("/logout".equals(path)) {
                 statusLine = handleLogout(request, responseHeaders);
                 responseBody = "";
-            } else if ("GET".equals(method)) {
+            } else if (Http11Method.GET.equals(method)) {
                 Entry<String, String> getResult = handleGetRequest(path, request, responseHeaders);
                 statusLine = getResult.getKey();
                 responseBody = getResult.getValue();
-            } else if ("POST".equals(method)) {
+            } else if (Http11Method.POST.equals(method)) {
                 statusLine = handlePostRequest(path, request, responseHeaders);
                 responseBody = "";
             }

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -122,16 +122,7 @@ public class Http11Processor implements Runnable, Processor {
         String statusLine = "HTTP/1.1 200 OK";
         String responseBody;
 
-        if ("/login".equals(path) || "/login.html".equals(path)) {
-            final Http11Cookie cookie = request.getCookie();
-            if (cookie.isContainsSessionId() && SessionManager.getInstance().containsSession(cookie.getSessionId())) {
-                statusLine = "HTTP/1.1 302 Found";
-                responseHeaders.put("Location", "/index.html");
-                responseBody = "";
-            } else {
-                responseBody = readFileFromClasspath("static/login.html");
-            }
-        } else if (!"/".equals(path)) {
+        if (!"/".equals(path)) {
             responseBody = readFileFromClasspath("static" + path);
             if (responseBody.isEmpty()) {
                 statusLine = "HTTP/1.1 404 Not Found";
@@ -147,39 +138,7 @@ public class Http11Processor implements Runnable, Processor {
     private String handlePostRequest(final String path, final Http11Request request, 
                                      final Map<String, String> responseHeaders) {
         Map<String, String> params = request.getParams();
-
-        if ("/login".equals(path)) {
-            try {
-                final User user = InMemoryUserRepository.findByAccount(params.get("account"))
-                        .orElseThrow(() -> new IllegalArgumentException("[ERROR] 회원을 찾을 수 없습니다."));
-
-                if (user.checkPassword(params.get("password"))) {
-                    createSessionAndSetCookie(user, request, responseHeaders);
-                    responseHeaders.put("Location", "/index.html");
-                    return "HTTP/1.1 302 Found";
-                } else {
-                    responseHeaders.put("Location", "/401.html");
-                    return "HTTP/1.1 302 Found";
-                }
-            } catch (IllegalArgumentException e) {
-                responseHeaders.put("Location", "/401.html");
-                return "HTTP/1.1 302 Found";
-            }
-        }
         return "HTTP/1.1 404 Not Found";
-    }
-
-    private void createSessionAndSetCookie(final User user, final Http11Request request, 
-                                           final Map<String, String> responseHeaders) {
-        final Http11Cookie cookie = request.getCookie();
-        if (cookie.isNotContainsSessionId() || !SessionManager.getInstance().containsSession(cookie.getSessionId())) {
-            final String sessionId = UUID.randomUUID().toString();
-            final Http11Session session = new Http11Session(sessionId);
-            session.setAttribute("user", user);
-            SessionManager.getInstance().add(session);
-            // TODO: CookieSecurityConfig를 통한 HttpOnly 기본, Secure/SameSite 설정 전략 등 고려하기
-            responseHeaders.put("Set-Cookie", "JSESSIONID=" + sessionId + "; Path=/");
-        }
     }
 
     private String readFileFromClasspath(String resourcePath) {

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -50,6 +50,7 @@ public class Http11Processor implements Runnable, Processor {
                 sendErrorResponse(outputStream);
                 return;
             }
+            final Http11Response response = new Http11Response();
 
             final String path = extractPath(request.getUri());
             final Http11Method method = request.getMethod();
@@ -72,11 +73,16 @@ public class Http11Processor implements Runnable, Processor {
             }
 
             responseHeaders.put("Content-Length", String.valueOf(responseBody.getBytes(StandardCharsets.UTF_8).length));
-            final String response = buildResponse(statusLine, responseHeaders, responseBody);
-            outputStream.write(response.getBytes(StandardCharsets.UTF_8));
+            response.putStatusLine(statusLine);
+            response.putHeaders(responseHeaders);
+            response.putBody(responseBody);
+
+            outputStream.write(response.buildResponse(StandardCharsets.UTF_8));
             outputStream.flush();
         } catch (IOException e) {
             log.error(e.getMessage(), e);
+        } catch (Http11ParseException ex) {
+            log.error(ex.getMessage(), ex);
         }
     }
 

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -122,9 +122,7 @@ public class Http11Processor implements Runnable, Processor {
         String statusLine = "HTTP/1.1 200 OK";
         String responseBody;
 
-        if ("/register".equals(path)) {
-            responseBody = readFileFromClasspath("static/register.html");
-        } else if ("/login".equals(path) || "/login.html".equals(path)) {
+        if ("/login".equals(path) || "/login.html".equals(path)) {
             final Http11Cookie cookie = request.getCookie();
             if (cookie.isContainsSessionId() && SessionManager.getInstance().containsSession(cookie.getSessionId())) {
                 statusLine = "HTTP/1.1 302 Found";
@@ -148,16 +146,7 @@ public class Http11Processor implements Runnable, Processor {
 
     private String handlePostRequest(final String path, final Http11Request request, 
                                      final Map<String, String> responseHeaders) {
-        final Map<String, String> params = parseRequestBody(request.getBody());
-
-        if ("/register".equals(path)) {
-            final User user = new User(params.get("account"), params.get("password"), params.get("email"));
-            InMemoryUserRepository.save(user);
-            log.info("User saved: {}", user);
-            createSessionAndSetCookie(user, request, responseHeaders);
-            responseHeaders.put("Location", "/index.html");
-            return "HTTP/1.1 302 Found";
-        }
+        Map<String, String> params = request.getParams();
 
         if ("/login".equals(path)) {
             try {

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -193,23 +193,6 @@ public class Http11Processor implements Runnable, Processor {
         }
     }
 
-    private Map<String, String> parseRequestBody(final String requestBody) {
-        if (requestBody == null || requestBody.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        final Map<String, String> params = new HashMap<>();
-        final String[] pairs = requestBody.split("&");
-        for (String pair : pairs) {
-            final String[] keyValue = pair.split("=", 2);
-            if (keyValue.length == 2) {
-                final String key = URLDecoder.decode(keyValue[0], StandardCharsets.UTF_8);
-                final String value = URLDecoder.decode(keyValue[1], StandardCharsets.UTF_8);
-                params.put(key, value);
-            }
-        }
-        return params;
-    }
-
     private String readFileFromClasspath(String resourcePath) {
         final InputStream input = getClass().getClassLoader().getResourceAsStream(resourcePath);
         if (input == null) {

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Request.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Request.java
@@ -10,7 +10,7 @@ import java.util.Map;
 
 public class Http11Request {
 
-    private String method;
+    private Http11Method method;
     private String uri;
     private String version;
     private Map<String, String> headers;
@@ -26,7 +26,7 @@ public class Http11Request {
             throw new Http11ParseException(ParseError.INVALID_REQUEST_LINE);
         }
 
-        this.method = requestLineParts[0];
+        this.method = Http11Method.from(requestLineParts[0]);
         this.uri = requestLineParts[1];
         this.version = requestLineParts[2];
 
@@ -52,7 +52,7 @@ public class Http11Request {
         this.cookie = new Http11Cookie(map.getOrDefault("Cookie", null));
     }
 
-    public String getMethod() {
+    public Http11Method getMethod() {
         return method;
     }
 

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Request.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Request.java
@@ -15,6 +15,8 @@ public class Http11Request {
     private Http11Method method;
     private String uri;
     private String version;
+    private String path;
+    private Map<String, String> params;
     private Map<String, String> headers;
     private String body;
     private Http11Cookie cookie;
@@ -31,6 +33,13 @@ public class Http11Request {
         this.method = Http11Method.from(requestLineParts[0]);
         this.uri = requestLineParts[1];
         this.version = requestLineParts[2];
+
+        int queryIndex = uri.indexOf("?");
+        if (queryIndex != -1) {
+            this.path = uri.substring(0, queryIndex);
+        } else {
+            this.path = uri; // 전체를 path 로 사용
+        }
 
         Map<String, String> map = new LinkedHashMap<>();
         String line;
@@ -68,6 +77,10 @@ public class Http11Request {
 
     public String getUri() {
         return uri;
+    }
+
+    public String getPath() {
+        return path;
     }
 
     public String getVersion() {

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Request.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Request.java
@@ -4,7 +4,10 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.apache.coyote.http11.exception.Http11ParseException;
@@ -60,6 +63,22 @@ public class Http11Request {
             this.body = "";
         }
 
+        if (this.body.isEmpty()) {
+            this.params = Collections.emptyMap();
+        } else {
+            final Map<String, String> params = new HashMap<>();
+            final String[] pairs = body.split("&");
+            for (String pair : pairs) {
+                final String[] keyValue = pair.split("=", 2);
+                if (keyValue.length == 2) {
+                    final String key = URLDecoder.decode(keyValue[0], StandardCharsets.UTF_8);
+                    final String value = URLDecoder.decode(keyValue[1], StandardCharsets.UTF_8);
+                    params.put(key, value);
+                }
+            }
+            this.params = params;
+        }
+
         this.cookie = new Http11Cookie(map.getOrDefault("Cookie", null));
     }
 
@@ -81,6 +100,10 @@ public class Http11Request {
 
     public String getPath() {
         return path;
+    }
+
+    public Map<String, String> getParams() {
+        return params;
     }
 
     public String getVersion() {

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Request.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Request.java
@@ -52,6 +52,14 @@ public class Http11Request {
         this.cookie = new Http11Cookie(map.getOrDefault("Cookie", null));
     }
 
+    public boolean isGet() {
+        return method == Http11Method.GET;
+    }
+
+    public boolean isPost() {
+        return method == Http11Method.POST;
+    }
+
     public Http11Method getMethod() {
         return method;
     }

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Request.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Request.java
@@ -41,7 +41,7 @@ public class Http11Request {
         if (queryIndex != -1) {
             this.path = uri.substring(0, queryIndex);
         } else {
-            this.path = uri; // 전체를 path 로 사용
+            this.path = uri;
         }
 
         Map<String, String> map = new LinkedHashMap<>();

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Request.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Request.java
@@ -106,6 +106,10 @@ public class Http11Request {
         return params;
     }
 
+    public String getParam(String name) {
+        return params.get(name);
+    }
+
     public String getVersion() {
         return version;
     }

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Request.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Request.java
@@ -23,12 +23,24 @@ public class Http11Request {
     private Map<String, String> headers;
     private String body;
     private Http11Cookie cookie;
+    private Http11Session session;
 
     public Http11Request(final InputStream inputStream) throws IOException, Http11ParseException {
         final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
-        String requestLine = reader.readLine();
-        String[] requestLineParts = requestLine.split(" ");
+        parseRequestLine(reader);
+        this.headers = parseHeaders(reader);
+        this.body = parseBody(reader);
+        this.params = parseParams();
+        this.cookie = parseCookies();
+    }
 
+    private void parseRequestLine(final BufferedReader reader) throws IOException, Http11ParseException {
+        final String requestLine = reader.readLine();
+        if (requestLine == null || requestLine.isEmpty()) {
+            throw new Http11ParseException(ParseError.INVALID_REQUEST_LINE);
+        }
+
+        final String[] requestLineParts = requestLine.split(" ");
         if (requestLineParts.length != 3) {
             throw new Http11ParseException(ParseError.INVALID_REQUEST_LINE);
         }
@@ -36,50 +48,74 @@ public class Http11Request {
         this.method = Http11Method.from(requestLineParts[0]);
         this.uri = requestLineParts[1];
         this.version = requestLineParts[2];
+        this.path = extractPath(uri);
+    }
 
+    private String extractPath(final String uri) {
         int queryIndex = uri.indexOf("?");
         if (queryIndex != -1) {
-            this.path = uri.substring(0, queryIndex);
-        } else {
-            this.path = uri;
+            return uri.substring(0, queryIndex);
         }
+        return uri;
+    }
 
-        Map<String, String> map = new LinkedHashMap<>();
+    private Map<String, String> parseHeaders(final BufferedReader reader) throws IOException {
+        final Map<String, String> headers = new LinkedHashMap<>();
         String line;
         while ((line = reader.readLine()) != null && !line.isEmpty()) {
-            String[] parts = line.split(":", 2);
+            final String[] parts = line.split(":", 2);
             if (parts.length == 2) {
-                map.put(parts[0].trim(), parts[1].trim());
+                headers.put(parts[0].trim(), parts[1].trim());
             }
         }
-        this.headers = map;
+        return headers;
+    }
 
-        if (map.containsKey("Content-Length")) { // TODO: Body 파싱 최적화
-            int contentLength = Integer.parseInt(map.get("Content-Length"));
+    private String parseBody(final BufferedReader reader) throws IOException {
+        if (headers.containsKey("Content-Length")) {
+            int contentLength = Integer.parseInt(headers.get("Content-Length"));
             char[] buffer = new char[contentLength];
             reader.read(buffer, 0, contentLength);
-            this.body = new String(buffer);
-        } else {
-            this.body = "";
+            return new String(buffer);
         }
+        return "";
+    }
 
-        if (this.body.isEmpty()) {
-            this.params = Collections.emptyMap();
-        } else {
-            final Map<String, String> params = new HashMap<>();
-            final String[] pairs = body.split("&");
-            for (String pair : pairs) {
-                final String[] keyValue = pair.split("=", 2);
-                if (keyValue.length == 2) {
-                    final String key = URLDecoder.decode(keyValue[0], StandardCharsets.UTF_8);
-                    final String value = URLDecoder.decode(keyValue[1], StandardCharsets.UTF_8);
-                    params.put(key, value);
-                }
+    private Map<String, String> parseParams() {
+        final Map<String, String> params = new HashMap<>();
+        addParamsFromQueryString(params);
+        addParamsFromBody(params);
+        return Collections.unmodifiableMap(params);
+    }
+
+    private void addParamsFromQueryString(final Map<String, String> params) {
+        int queryIndex = uri.indexOf("?");
+        if (queryIndex != -1) {
+            final String queryString = uri.substring(queryIndex + 1);
+            parseQueryString(queryString, params);
+        }
+    }
+
+    private void addParamsFromBody(final Map<String, String> params) {
+        if (isPost() && body != null && !body.isEmpty()) {
+            parseQueryString(body, params);
+        }
+    }
+
+    private void parseQueryString(final String queryString, final Map<String, String> params) {
+        final String[] pairs = queryString.split("&");
+        for (String pair : pairs) {
+            final String[] keyValue = pair.split("=", 2);
+            if (keyValue.length == 2) {
+                final String key = URLDecoder.decode(keyValue[0], StandardCharsets.UTF_8);
+                final String value = URLDecoder.decode(keyValue[1], StandardCharsets.UTF_8);
+                params.put(key, value);
             }
-            this.params = params;
         }
+    }
 
-        this.cookie = new Http11Cookie(map.getOrDefault("Cookie", null));
+    private Http11Cookie parseCookies() {
+        return new Http11Cookie(headers.getOrDefault("Cookie", ""));
     }
 
     public boolean isGet() {
@@ -90,32 +126,12 @@ public class Http11Request {
         return method == Http11Method.POST;
     }
 
-    public Http11Method getMethod() {
-        return method;
-    }
-
-    public String getUri() {
-        return uri;
-    }
-
     public String getPath() {
         return path;
     }
 
-    public Map<String, String> getParams() {
-        return params;
-    }
-
     public String getParam(String name) {
         return params.get(name);
-    }
-
-    public String getVersion() {
-        return version;
-    }
-
-    public Map<String, String> getHeaders() {
-        return headers;
     }
 
     public String getBody() {

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Request.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Request.java
@@ -7,6 +7,8 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.apache.coyote.http11.exception.Http11ParseException;
+import org.apache.coyote.http11.exception.ParseError;
 
 public class Http11Request {
 

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Response.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Response.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
@@ -18,11 +19,17 @@ public class Http11Response {
     private static final Logger log = LoggerFactory.getLogger(Http11Processor.class);
     private static final String CRLF = "\r\n";
 
+    private OutputStream outputStream;
+    private String statusLine;
     private String version;
     private int code;
     private String message;
     private Map<String, String> headers = new LinkedHashMap<>();
     private String body;
+
+    public Http11Response(OutputStream outputStream) {
+        this.outputStream = outputStream;
+    }
 
     public byte[] buildResponse(Charset charset) throws IOException {
         headers.put("Content-Length", String.valueOf(body.getBytes(StandardCharsets.UTF_8).length));
@@ -62,6 +69,15 @@ public class Http11Response {
     public void sendRedirect(String path) throws Http11ParseException {
         putStatusLine("HTTP/1.1 302 Found");
         putHeader("Location", "/index.html");
+    }
+
+    public void sendError() {
+        this.statusLine = "HTTP/1.1 400 Bad Request";
+        String responseBody = readFileFromClasspath("static/400.html");
+        final Map<String, String> responseHeaders = new LinkedHashMap<>();
+        responseHeaders.put("Content-Type", MediaType.HTML.getMimeType());
+        responseHeaders.put("Content-Length", String.valueOf(responseBody.getBytes(StandardCharsets.UTF_8).length));
+        this.headers = responseHeaders;
     }
 
     public void putStatusLine(String line) throws Http11ParseException {

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Response.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Response.java
@@ -21,10 +21,9 @@ public class Http11Response {
     private static final String CRLF = "\r\n";
 
     private OutputStream outputStream;
-    private String statusLine;
-    private String version;
-    private int code;
-    private String message;
+    private String version = "HTTP/1.1";
+    private int code = 200;
+    private String message = "OK";
     private Map<String, String> headers = new LinkedHashMap<>();
     private String body;
 
@@ -33,7 +32,6 @@ public class Http11Response {
     }
 
     public byte[] buildResponse(Charset charset) throws IOException {
-        headers.put("Content-Length", String.valueOf(body.getBytes(StandardCharsets.UTF_8).length));
         final String statusLine = String.join(" ", version, String.valueOf(code), message);
         final StringBuilder responseBuilder = new StringBuilder();
         responseBuilder.append(statusLine).append(CRLF);
@@ -48,11 +46,10 @@ public class Http11Response {
         return responseBuilder.toString().getBytes(charset);
     }
 
-    public String readFileFromClasspath(String resourcePath) {
+    public void readFileFromClasspath(String resourcePath) {
         final InputStream input = getClass().getClassLoader().getResourceAsStream(resourcePath);
         if (input == null) {
             log.error("resource not found: {}", resourcePath);
-            return "";
         }
         final StringBuilder fileContents = new StringBuilder();
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(input))) {
@@ -62,32 +59,35 @@ public class Http11Response {
             }
         } catch (IOException e) {
             log.error("Failed to read file: {}", resourcePath, e);
-            return "";
         }
-        return fileContents.toString();
+
+        this.body = fileContents.toString();
+        headers.put("Content-Type", MediaType.detectMimeType(resourcePath));
+        headers.put("Content-Length", String.valueOf(body.getBytes(StandardCharsets.UTF_8).length));
     }
 
-    public void sendRedirect(String path) throws Http11ParseException {
+    public void sendRedirect(String path) {
         putStatusLine("HTTP/1.1 302 Found");
         putHeader("Location", path);
     }
 
     public void sendError(int code) throws Http11ParseException {
         Http11Status status = Http11Status.findByCode(code);
-        this.statusLine = status.getStatusLine();
-        String responseBody = readFileFromClasspath(ErrorResourceMapper.getResource(400));
-        final Map<String, String> responseHeaders = new LinkedHashMap<>();
-        responseHeaders.put("Content-Type", MediaType.HTML.getMimeType());
-        responseHeaders.put("Content-Length", String.valueOf(responseBody.getBytes(StandardCharsets.UTF_8).length));
-        this.headers = responseHeaders;
+        String statusLine = status.getStatusLine();
+        String[] statusLineParts = statusLine.split(" ", 3);
+        this.version = statusLineParts[1];
+        this.code = Integer.parseInt(statusLineParts[2]);
+        this.message = statusLineParts[3];
+
+        readFileFromClasspath(ErrorResourceMapper.getResource(400));
     }
 
     public void sendError(Http11Status status) throws Http11ParseException {
         sendError(status.getCode());
     }
 
-    public void putStatusLine(String line) throws Http11ParseException {
-        String[] lineParts = line.split(" ");
+    public void putStatusLine(String line) {
+        String[] lineParts = line.split(" ", 3);
         this.version = lineParts[0];
         this.code = Integer.parseInt(lineParts[1]);
         this.message = lineParts[2];

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Response.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Response.java
@@ -11,6 +11,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import org.apache.coyote.http11.exception.Http11ParseException;
+import org.apache.coyote.http11.exception.util.ErrorResourceMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,16 +69,21 @@ public class Http11Response {
 
     public void sendRedirect(String path) throws Http11ParseException {
         putStatusLine("HTTP/1.1 302 Found");
-        putHeader("Location", "/index.html");
+        putHeader("Location", path);
     }
 
-    public void sendError() {
-        this.statusLine = "HTTP/1.1 400 Bad Request";
-        String responseBody = readFileFromClasspath("static/400.html");
+    public void sendError(int code) throws Http11ParseException {
+        Http11Status status = Http11Status.findByCode(code);
+        this.statusLine = status.getStatusLine();
+        String responseBody = readFileFromClasspath(ErrorResourceMapper.getResource(400));
         final Map<String, String> responseHeaders = new LinkedHashMap<>();
         responseHeaders.put("Content-Type", MediaType.HTML.getMimeType());
         responseHeaders.put("Content-Length", String.valueOf(responseBody.getBytes(StandardCharsets.UTF_8).length));
         this.headers = responseHeaders;
+    }
+
+    public void sendError(Http11Status status) throws Http11ParseException {
+        sendError(status.getCode());
     }
 
     public void putStatusLine(String line) throws Http11ParseException {

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Response.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Response.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -24,6 +25,7 @@ public class Http11Response {
     private String body;
 
     public byte[] buildResponse(Charset charset) throws IOException {
+        headers.put("Content-Length", String.valueOf(body.getBytes(StandardCharsets.UTF_8).length));
         final String statusLine = String.join(" ", version, String.valueOf(code), message);
         final StringBuilder responseBuilder = new StringBuilder();
         responseBuilder.append(statusLine).append(CRLF);

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Response.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Response.java
@@ -53,13 +53,12 @@ public class Http11Response {
         outputStream.flush();
     }
 
-    public void sendRedirect(final String path) throws IOException {
+    public void sendRedirect(final String path) {
         setStatus(Http11Status.FOUND);
         putHeader(LOCATION, path);
-        send();
     }
 
-    public void sendError(final Http11Status status) throws IOException {
+    public void sendError(final Http11Status status) {
         try {
             setStatus(status);
             final String resourcePath = ErrorResourceMapper.getResource(status.getCode());
@@ -72,7 +71,6 @@ public class Http11Response {
             putHeader(CONTENT_TYPE, "text/plain; charset=utf-8");
             putHeader(CONTENT_LENGTH, String.valueOf(body.getBytes(StandardCharsets.UTF_8).length));
         }
-        send();
     }
 
     public void readFileFromClasspath(final String resourcePath) throws IOException {

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Response.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Response.java
@@ -57,6 +57,11 @@ public class Http11Response {
         return fileContents.toString();
     }
 
+    public void sendRedirect(String path) throws Http11ParseException {
+        putStatusLine("HTTP/1.1 302 Found");
+        putHeader("Location", "/index.html");
+    }
+
     public void putStatusLine(String line) throws Http11ParseException {
         String[] lineParts = line.split(" ");
         this.version = lineParts[0];

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Response.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Response.java
@@ -5,103 +5,104 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-import org.apache.coyote.http11.exception.Http11ParseException;
 import org.apache.coyote.http11.exception.util.ErrorResourceMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class Http11Response {
 
-    private static final Logger log = LoggerFactory.getLogger(Http11Processor.class);
-    private static final String CRLF = "\r\n";
+    private static final Logger log = LoggerFactory.getLogger(Http11Response.class);
 
-    private OutputStream outputStream;
-    private String version = "HTTP/1.1";
+    private static final String CRLF = "\r\n";
+    private static final String HTTP_VERSION = "HTTP/1.1";
+    private static final String LOCATION = "Location";
+    private static final String CONTENT_TYPE = "Content-Type";
+    private static final String CONTENT_LENGTH = "Content-Length";
+
+    private final OutputStream outputStream;
+
+    private String version = HTTP_VERSION;
     private int code = 200;
     private String message = "OK";
-    private Map<String, String> headers = new LinkedHashMap<>();
+    private final Map<String, String> headers = new LinkedHashMap<>();
     private String body;
 
-    public Http11Response(OutputStream outputStream) {
+    public Http11Response(final OutputStream outputStream) {
         this.outputStream = outputStream;
     }
 
-    public byte[] buildResponse(Charset charset) throws IOException {
-        final String statusLine = String.join(" ", version, String.valueOf(code), message);
-        final StringBuilder responseBuilder = new StringBuilder();
-        responseBuilder.append(statusLine).append(CRLF);
-        for (Entry<String, String> entry : headers.entrySet()) {
-            responseBuilder.append(entry.getKey())
-                    .append(": ")
-                    .append(entry.getValue())
-                    .append(CRLF);
+    public void send() throws IOException {
+        final String statusLine = String.join(" ", version, String.valueOf(code), message) + CRLF;
+        outputStream.write(statusLine.getBytes(StandardCharsets.UTF_8));
+
+        for (final Entry<String, String> entry : headers.entrySet()) {
+            final String header = entry.getKey() + ": " + entry.getValue() + CRLF;
+            outputStream.write(header.getBytes(StandardCharsets.UTF_8));
         }
-        responseBuilder.append(CRLF);
-        responseBuilder.append(body);
-        return responseBuilder.toString().getBytes(charset);
+
+        outputStream.write(CRLF.getBytes(StandardCharsets.UTF_8));
+
+        if (body != null) {
+            outputStream.write(body.getBytes(StandardCharsets.UTF_8));
+        }
+
+        outputStream.flush();
     }
 
-    public void readFileFromClasspath(String resourcePath) {
+    public void sendRedirect(final String path) throws IOException {
+        setStatus(Http11Status.FOUND);
+        putHeader(LOCATION, path);
+        send();
+    }
+
+    public void sendError(final Http11Status status) throws IOException {
+        try {
+            setStatus(status);
+            final String resourcePath = ErrorResourceMapper.getResource(status.getCode());
+            readFileFromClasspath(resourcePath);
+        } catch (final IOException e) {
+            log.error("Failed to send error page for status {}. reason: {}", status, e.getMessage());
+            setStatus(status);
+            final String message = status.getStatusLine().split(" ", 3)[2];
+            setBody(status.getCode() + " " + message);
+            putHeader(CONTENT_TYPE, "text/plain; charset=utf-8");
+            putHeader(CONTENT_LENGTH, String.valueOf(body.getBytes(StandardCharsets.UTF_8).length));
+        }
+        send();
+    }
+
+    public void readFileFromClasspath(final String resourcePath) throws IOException {
         final InputStream input = getClass().getClassLoader().getResourceAsStream(resourcePath);
         if (input == null) {
-            log.error("resource not found: {}", resourcePath);
+            throw new IOException("Resource not found: " + resourcePath);
         }
+
         final StringBuilder fileContents = new StringBuilder();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(input))) {
+        try (final BufferedReader reader = new BufferedReader(new InputStreamReader(input))) {
             String line;
             while ((line = reader.readLine()) != null) {
                 fileContents.append(line).append(CRLF);
             }
-        } catch (IOException e) {
-            log.error("Failed to read file: {}", resourcePath, e);
         }
-
-        this.body = fileContents.toString();
-        headers.put("Content-Type", MediaType.detectMimeType(resourcePath));
-        headers.put("Content-Length", String.valueOf(body.getBytes(StandardCharsets.UTF_8).length));
+        setBody(fileContents.toString());
+        putHeader(CONTENT_TYPE, MediaType.detectMimeType(resourcePath));
+        putHeader(CONTENT_LENGTH, String.valueOf(body.getBytes(StandardCharsets.UTF_8).length));
     }
 
-    public void sendRedirect(String path) {
-        putStatusLine("HTTP/1.1 302 Found");
-        putHeader("Location", path);
+    public void setStatus(final Http11Status status) {
+        this.code = status.getCode();
+        this.message = status.getStatusLine().split(" ", 3)[2];
     }
 
-    public void sendError(int code) throws Http11ParseException {
-        Http11Status status = Http11Status.findByCode(code);
-        String statusLine = status.getStatusLine();
-        String[] statusLineParts = statusLine.split(" ", 3);
-        this.version = statusLineParts[1];
-        this.code = Integer.parseInt(statusLineParts[2]);
-        this.message = statusLineParts[3];
-
-        readFileFromClasspath(ErrorResourceMapper.getResource(400));
-    }
-
-    public void sendError(Http11Status status) throws Http11ParseException {
-        sendError(status.getCode());
-    }
-
-    public void putStatusLine(String line) {
-        String[] lineParts = line.split(" ", 3);
-        this.version = lineParts[0];
-        this.code = Integer.parseInt(lineParts[1]);
-        this.message = lineParts[2];
-    }
-
-    public void putHeader(String name, String value) {
+    public void putHeader(final String name, final String value) {
         this.headers.put(name, value);
     }
 
-    public void putHeaders(Map<String, String> headers) {
-        this.headers.putAll(headers);
-    }
-
-    public void putBody(String body) {
+    public void setBody(final String body) {
         this.body = body;
     }
 

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Response.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Response.java
@@ -2,10 +2,10 @@ package org.apache.coyote.http11;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import org.apache.coyote.http11.exception.Http11ParseException;
 
 public class Http11Response {
 

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Response.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Response.java
@@ -1,0 +1,57 @@
+package org.apache.coyote.http11;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+public class Http11Response {
+
+    private static final String CRLF = "\r\n";
+
+    private String version;
+    private int code;
+    private String message;
+    private Map<String, String> headers = new LinkedHashMap<>();
+    private String body;
+
+    public byte[] buildResponse(Charset charset) throws IOException {
+        final String statusLine = String.join(" ", version, String.valueOf(code), message);
+        final StringBuilder responseBuilder = new StringBuilder();
+        responseBuilder.append(statusLine).append(CRLF);
+        for (Entry<String, String> entry : headers.entrySet()) {
+            responseBuilder.append(entry.getKey())
+                    .append(": ")
+                    .append(entry.getValue())
+                    .append(CRLF);
+        }
+        responseBuilder.append(CRLF);
+        responseBuilder.append(body);
+        return responseBuilder.toString().getBytes(charset);
+    }
+
+    public void putStatusLine(String line) throws Http11ParseException {
+        String[] lineParts = line.split(" ");
+        this.version = lineParts[0];
+        this.code = Integer.parseInt(lineParts[1]);
+        this.message = lineParts[2];
+    }
+
+    public void putHeader(String name, String value) {
+        this.headers.put(name, value);
+    }
+
+    public void putHeaders(Map<String, String> headers) {
+        this.headers.putAll(headers);
+    }
+
+    public void putBody(String body) {
+        this.body = body;
+    }
+
+    public String getBody() {
+        return body;
+    }
+}

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Response.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Response.java
@@ -1,14 +1,20 @@
 package org.apache.coyote.http11;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import org.apache.coyote.http11.exception.Http11ParseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Http11Response {
 
+    private static final Logger log = LoggerFactory.getLogger(Http11Processor.class);
     private static final String CRLF = "\r\n";
 
     private String version;
@@ -30,6 +36,25 @@ public class Http11Response {
         responseBuilder.append(CRLF);
         responseBuilder.append(body);
         return responseBuilder.toString().getBytes(charset);
+    }
+
+    public String readFileFromClasspath(String resourcePath) {
+        final InputStream input = getClass().getClassLoader().getResourceAsStream(resourcePath);
+        if (input == null) {
+            log.error("resource not found: {}", resourcePath);
+            return "";
+        }
+        final StringBuilder fileContents = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(input))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                fileContents.append(line).append(CRLF);
+            }
+        } catch (IOException e) {
+            log.error("Failed to read file: {}", resourcePath, e);
+            return "";
+        }
+        return fileContents.toString();
     }
 
     public void putStatusLine(String line) throws Http11ParseException {

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Status.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Status.java
@@ -11,6 +11,7 @@ public enum Http11Status {
     BAD_REQUEST(400, "HTTP/1.1 400 Bad Request"),
     UNAUTHORIZED(401, "HTTP/1.1 401 Unauthorized"),
     NOT_FOUND(404, "HTTP/1.1 404 Not Found"),
+    METHOD_NOT_ALLOW(405, "HTTP/1.1 405 Method Not Allowed"),
     INTERNAL_SERVER_ERROR(500, "HTTP/1.1 500 Internal Server Error");
 
     private final int code;

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Status.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Status.java
@@ -1,0 +1,38 @@
+package org.apache.coyote.http11;
+
+import java.util.Arrays;
+import org.apache.coyote.http11.exception.Http11ParseException;
+import org.apache.coyote.http11.exception.ParseError;
+
+public enum Http11Status {
+
+    OK(200, "HTTP/1.1 200 OK"),
+    BAD_REQUEST(400, "HTTP/1.1 400 Bad Request"),
+    UNAUTHORIZED(401,"HTTP/1.1 401 Unauthorized"),
+    NOT_FOUND(404, "HTTP/1.1 404 Not Found"),
+    INTERNAL_SERVER_ERROR(500, "HTTP/1.1 500 Internal Server Error");
+
+    private final int code;
+    private final String statusLine;
+
+    Http11Status(int code, String statusLine) {
+        this.code = code;
+        this.statusLine = statusLine;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getStatusLine() {
+        return statusLine;
+    }
+
+    public static Http11Status findByCode(int code) throws Http11ParseException {
+        return Arrays.stream(values())
+                .filter(status -> status.code == code)
+                .findFirst()
+                .orElseThrow(() -> new Http11ParseException(ParseError.INVALID_HTTP_METHOD));
+    }
+}
+

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Status.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Status.java
@@ -7,8 +7,9 @@ import org.apache.coyote.http11.exception.ParseError;
 public enum Http11Status {
 
     OK(200, "HTTP/1.1 200 OK"),
+    FOUND(302, "HTTP/1.1 302 Found"),
     BAD_REQUEST(400, "HTTP/1.1 400 Bad Request"),
-    UNAUTHORIZED(401,"HTTP/1.1 401 Unauthorized"),
+    UNAUTHORIZED(401, "HTTP/1.1 401 Unauthorized"),
     NOT_FOUND(404, "HTTP/1.1 404 Not Found"),
     INTERNAL_SERVER_ERROR(500, "HTTP/1.1 500 Internal Server Error");
 

--- a/tomcat/src/main/java/org/apache/coyote/http11/ParseError.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/ParseError.java
@@ -2,7 +2,8 @@ package org.apache.coyote.http11;
 
 public enum ParseError {
 
-    INVALID_REQUEST_LINE(400, "Invalid request line");
+    INVALID_REQUEST_LINE(400, "Invalid request line"),
+    INVALID_HTTP_METHOD(400, "Invalid http method");
 
     private final int statusCode;
     private final String message;

--- a/tomcat/src/main/java/org/apache/coyote/http11/SessionManager.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/SessionManager.java
@@ -1,6 +1,7 @@
 package org.apache.coyote.http11;
 
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.catalina.Manager;
 
@@ -11,6 +12,13 @@ public class SessionManager implements Manager {
 
     public static SessionManager getInstance() {
         return INSTANCE;
+    }
+
+    public static Http11Session createSession() {
+        String sessionId = UUID.randomUUID().toString();
+        Http11Session session = new Http11Session(sessionId);
+        SESSIONS.put(sessionId, session);
+        return session;
     }
 
     @Override

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/AbstractController.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/AbstractController.java
@@ -2,20 +2,30 @@ package org.apache.coyote.http11.controller;
 
 import org.apache.coyote.http11.Http11Request;
 import org.apache.coyote.http11.Http11Response;
+import org.apache.coyote.http11.Http11Status;
 
 public abstract class AbstractController implements Controller {
 
     @Override
     public void service(Http11Request request, Http11Response response) throws Exception {
-        if (request.isGet()) doGet(request, response);
-        if (request.isPost()) doPost(request, response);
+        if (request.isGet()) {
+            doGet(request, response);
+            return;
+        }
+
+        if (request.isPost()) {
+            doPost(request, response);
+            return;
+        }
+
+        response.sendError(Http11Status.METHOD_NOT_ALLOW);
     }
 
     protected void doGet(Http11Request request, Http11Response response) throws Exception {
-        /* NOOP */
+        response.sendError(Http11Status.METHOD_NOT_ALLOW);
     }
 
     protected void doPost(Http11Request request, Http11Response response) throws Exception {
-        /* NOOP */
+        response.sendError(Http11Status.METHOD_NOT_ALLOW);
     }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/AbstractController.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/AbstractController.java
@@ -1,0 +1,21 @@
+package org.apache.coyote.http11.controller;
+
+import org.apache.coyote.http11.Http11Request;
+import org.apache.coyote.http11.Http11Response;
+
+public abstract class AbstractController implements Controller {
+
+    @Override
+    public void service(Http11Request request, Http11Response response) throws Exception {
+        if (request.isGet()) doGet(request, response);
+        if (request.isPost()) doPost(request, response);
+    }
+
+    protected void doPost(Http11Request request, Http11Response response) throws Exception {
+        /* NOOP */
+    }
+
+    protected void doGet(Http11Request request, Http11Response response) throws Exception {
+        /* NOOP */
+    }
+}

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/AbstractController.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/AbstractController.java
@@ -11,11 +11,11 @@ public abstract class AbstractController implements Controller {
         if (request.isPost()) doPost(request, response);
     }
 
-    protected void doPost(Http11Request request, Http11Response response) throws Exception {
+    protected void doGet(Http11Request request, Http11Response response) throws Exception {
         /* NOOP */
     }
 
-    protected void doGet(Http11Request request, Http11Response response) throws Exception {
+    protected void doPost(Http11Request request, Http11Response response) throws Exception {
         /* NOOP */
     }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/Controller.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/Controller.java
@@ -1,0 +1,9 @@
+package org.apache.coyote.http11.controller;
+
+import org.apache.coyote.http11.Http11Request;
+import org.apache.coyote.http11.Http11Response;
+
+public interface Controller {
+
+    void service(Http11Request request, Http11Response response) throws Exception;
+}

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/IndexController.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/IndexController.java
@@ -1,0 +1,13 @@
+package org.apache.coyote.http11.controller;
+
+import org.apache.coyote.http11.Http11Request;
+import org.apache.coyote.http11.Http11Response;
+
+public class IndexController extends AbstractController {
+
+    @Override
+    protected void doGet(Http11Request request, Http11Response response) throws Exception {
+        response.putHeader("Content-Type", "text/html; charset=utf-8");
+        response.putBody(response.readFileFromClasspath("index.html"));
+    }
+}

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/IndexController.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/IndexController.java
@@ -8,6 +8,6 @@ public class IndexController extends AbstractController {
     @Override
     protected void doGet(Http11Request request, Http11Response response) throws Exception {
         response.putHeader("Content-Type", "text/html; charset=utf-8");
-        response.putBody(response.readFileFromClasspath("index.html"));
+        response.readFileFromClasspath("static/index.html");
     }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/LoginController.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/LoginController.java
@@ -11,10 +11,12 @@ import org.apache.coyote.http11.SessionManager;
 
 public class LoginController extends AbstractController {
 
+    private static final String JSESSIONID = "JSESSIONID";
+
     @Override
     protected void doGet(Http11Request request, Http11Response response) throws Exception {
         final Http11Cookie cookie = request.getCookie();
-        if (cookie.isContainsSessionId() && SessionManager.getInstance().containsSession(cookie.getSessionId())) {
+        if (cookie.containsKey(JSESSIONID) && SessionManager.getInstance().containsSession(cookie.get(JSESSIONID))) {
             response.sendRedirect("/index.html");
             return;
         }

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/LoginController.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/LoginController.java
@@ -8,12 +8,11 @@ import org.apache.coyote.http11.Http11Response;
 import org.apache.coyote.http11.Http11Session;
 import org.apache.coyote.http11.MediaType;
 import org.apache.coyote.http11.SessionManager;
-import org.apache.coyote.http11.exception.Http11ParseException;
 
 public class LoginController extends AbstractController {
 
     @Override
-    protected void doGet(Http11Request request, Http11Response response) throws Http11ParseException {
+    protected void doGet(Http11Request request, Http11Response response) throws Exception {
         final Http11Cookie cookie = request.getCookie();
         if (cookie.isContainsSessionId() && SessionManager.getInstance().containsSession(cookie.getSessionId())) {
             response.sendRedirect("/index.html");
@@ -24,7 +23,7 @@ public class LoginController extends AbstractController {
     }
 
     @Override
-    protected void doPost(Http11Request request, Http11Response response) throws Http11ParseException {
+    protected void doPost(Http11Request request, Http11Response response) throws Exception {
         try {
             final User user = InMemoryUserRepository.findByAccount(request.getParam("account"))
                     .orElseThrow(() -> new IllegalArgumentException("[ERROR] 회원을 찾을 수 없습니다."));

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/LoginController.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/LoginController.java
@@ -2,53 +2,43 @@ package org.apache.coyote.http11.controller;
 
 import com.techcourse.db.InMemoryUserRepository;
 import com.techcourse.model.User;
-import java.util.UUID;
 import org.apache.coyote.http11.Http11Cookie;
 import org.apache.coyote.http11.Http11Request;
 import org.apache.coyote.http11.Http11Response;
 import org.apache.coyote.http11.Http11Session;
+import org.apache.coyote.http11.MediaType;
 import org.apache.coyote.http11.SessionManager;
+import org.apache.coyote.http11.exception.Http11ParseException;
 
 public class LoginController extends AbstractController {
 
     @Override
-    protected void doGet(Http11Request request, Http11Response response) throws Exception {
+    protected void doGet(Http11Request request, Http11Response response) throws Http11ParseException {
         final Http11Cookie cookie = request.getCookie();
         if (cookie.isContainsSessionId() && SessionManager.getInstance().containsSession(cookie.getSessionId())) {
-            response.putStatusLine("HTTP/1.1 302 Found");
-            response.putHeader("Location", "/index.html");
-            response.putBody("");
-        } else {
-            response.putBody(response.readFileFromClasspath("static/login.html"));
+            response.sendRedirect("/index.html");
+            return;
         }
+        response.putHeader("Content-Type", MediaType.HTML.getMimeType());
+        response.putBody(response.readFileFromClasspath("static/login.html"));
     }
 
     @Override
-    protected void doPost(Http11Request request, Http11Response response) throws Exception {
+    protected void doPost(Http11Request request, Http11Response response) throws Http11ParseException {
         try {
             final User user = InMemoryUserRepository.findByAccount(request.getParam("account"))
                     .orElseThrow(() -> new IllegalArgumentException("[ERROR] 회원을 찾을 수 없습니다."));
 
             if (user.checkPassword(request.getParam("password"))) {
-                createSessionAndSetCookie(user, request, response);
-                response.sendRedirect("/401.html");
-            } else {
-                response.sendRedirect("/401.html");
+                final Http11Session session = SessionManager.createSession();
+                session.setAttribute("user", user);
+                response.putHeader("Set-Cookie", "JSESSIONID=" + session.getId() + "; Path=/");
+                response.sendRedirect("/index.html");
+                return;
             }
+            response.sendRedirect("/401.html");
         } catch (IllegalArgumentException e) {
             response.sendRedirect("/401.html");
-        }
-    }
-
-    private void createSessionAndSetCookie(final User user, final Http11Request request, final Http11Response response) {
-        final Http11Cookie cookie = request.getCookie();
-        if (cookie.isNotContainsSessionId() || !SessionManager.getInstance().containsSession(cookie.getSessionId())) {
-            final String sessionId = UUID.randomUUID().toString();
-            final Http11Session session = new Http11Session(sessionId);
-            session.setAttribute("user", user);
-            SessionManager.getInstance().add(session);
-            // TODO: CookieSecurityConfig를 통한 HttpOnly 기본, Secure/SameSite 설정 전략 등 고려하기
-            response.putHeader("Set-Cookie", "JSESSIONID=" + sessionId + "; Path=/");
         }
     }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/LoginController.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/LoginController.java
@@ -1,0 +1,54 @@
+package org.apache.coyote.http11.controller;
+
+import com.techcourse.db.InMemoryUserRepository;
+import com.techcourse.model.User;
+import java.util.UUID;
+import org.apache.coyote.http11.Http11Cookie;
+import org.apache.coyote.http11.Http11Request;
+import org.apache.coyote.http11.Http11Response;
+import org.apache.coyote.http11.Http11Session;
+import org.apache.coyote.http11.SessionManager;
+
+public class LoginController extends AbstractController {
+
+    @Override
+    protected void doGet(Http11Request request, Http11Response response) throws Exception {
+        final Http11Cookie cookie = request.getCookie();
+        if (cookie.isContainsSessionId() && SessionManager.getInstance().containsSession(cookie.getSessionId())) {
+            response.putStatusLine("HTTP/1.1 302 Found");
+            response.putHeader("Location", "/index.html");
+            response.putBody("");
+        } else {
+            response.putBody(response.readFileFromClasspath("static/login.html"));
+        }
+    }
+
+    @Override
+    protected void doPost(Http11Request request, Http11Response response) throws Exception {
+        try {
+            final User user = InMemoryUserRepository.findByAccount(request.getParam("account"))
+                    .orElseThrow(() -> new IllegalArgumentException("[ERROR] 회원을 찾을 수 없습니다."));
+
+            if (user.checkPassword(request.getParam("password"))) {
+                createSessionAndSetCookie(user, request, response);
+                response.sendRedirect("/401.html");
+            } else {
+                response.sendRedirect("/401.html");
+            }
+        } catch (IllegalArgumentException e) {
+            response.sendRedirect("/401.html");
+        }
+    }
+
+    private void createSessionAndSetCookie(final User user, final Http11Request request, final Http11Response response) {
+        final Http11Cookie cookie = request.getCookie();
+        if (cookie.isNotContainsSessionId() || !SessionManager.getInstance().containsSession(cookie.getSessionId())) {
+            final String sessionId = UUID.randomUUID().toString();
+            final Http11Session session = new Http11Session(sessionId);
+            session.setAttribute("user", user);
+            SessionManager.getInstance().add(session);
+            // TODO: CookieSecurityConfig를 통한 HttpOnly 기본, Secure/SameSite 설정 전략 등 고려하기
+            response.putHeader("Set-Cookie", "JSESSIONID=" + sessionId + "; Path=/");
+        }
+    }
+}

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/LoginController.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/LoginController.java
@@ -20,7 +20,7 @@ public class LoginController extends AbstractController {
             return;
         }
         response.putHeader("Content-Type", MediaType.HTML.getMimeType());
-        response.putBody(response.readFileFromClasspath("static/login.html"));
+        response.readFileFromClasspath("static/login.html");
     }
 
     @Override

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/LogoutController.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/LogoutController.java
@@ -7,11 +7,13 @@ import org.apache.coyote.http11.SessionManager;
 
 public class LogoutController extends AbstractController {
 
+    private static final String JSESSIONID = "JSESSIONID";
+
     @Override
     protected void doGet(Http11Request request, Http11Response response) throws Exception {
         final Http11Cookie cookie = request.getCookie();
-        if (cookie.isContainsSessionId()) {
-            SessionManager.getInstance().remove(cookie.getSessionId());
+        if (cookie.containsKey(JSESSIONID)) {
+            SessionManager.getInstance().remove(cookie.get(JSESSIONID));
         }
         response.putHeader("Set-Cookie", "JSESSIONID=; Path=/; Max-Age=0");
         response.sendRedirect("/index.html");

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/LogoutController.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/LogoutController.java
@@ -1,0 +1,19 @@
+package org.apache.coyote.http11.controller;
+
+import org.apache.coyote.http11.Http11Cookie;
+import org.apache.coyote.http11.Http11Request;
+import org.apache.coyote.http11.Http11Response;
+import org.apache.coyote.http11.SessionManager;
+
+public class LogoutController extends AbstractController {
+
+    @Override
+    protected void doGet(Http11Request request, Http11Response response) throws Exception {
+        final Http11Cookie cookie = request.getCookie();
+        if (cookie.isContainsSessionId()) {
+            SessionManager.getInstance().remove(cookie.getSessionId());
+        }
+        response.putHeader("Set-Cookie", "JSESSIONID=; Path=/; Max-Age=0");
+        response.sendRedirect("/index.html");
+    }
+}

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/RegisterController.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/RegisterController.java
@@ -2,9 +2,6 @@ package org.apache.coyote.http11.controller;
 
 import com.techcourse.db.InMemoryUserRepository;
 import com.techcourse.model.User;
-import java.util.Map;
-import java.util.UUID;
-import org.apache.coyote.http11.Http11Cookie;
 import org.apache.coyote.http11.Http11Request;
 import org.apache.coyote.http11.Http11Response;
 import org.apache.coyote.http11.Http11Session;
@@ -27,20 +24,10 @@ public class RegisterController extends AbstractController {
         final User user = new User(request.getParam("account"), request.getParam("password"), request.getParam("email"));
         InMemoryUserRepository.save(user);
         log.info("User saved: {}", user);
-        createSessionAndSetCookie(user, request, response);
-        response.putStatusLine("HTTP/1.1 302 Found");
-        response.putHeader("Location", "/index.html");
-    }
 
-    private void createSessionAndSetCookie(final User user, final Http11Request request, final Http11Response response) {
-        final Http11Cookie cookie = request.getCookie();
-        if (cookie.isNotContainsSessionId() || !SessionManager.getInstance().containsSession(cookie.getSessionId())) {
-            final String sessionId = UUID.randomUUID().toString();
-            final Http11Session session = new Http11Session(sessionId);
-            session.setAttribute("user", user);
-            SessionManager.getInstance().add(session);
-            // TODO: CookieSecurityConfig를 통한 HttpOnly 기본, Secure/SameSite 설정 전략 등 고려하기
-            response.putHeader("Set-Cookie", "JSESSIONID=" + sessionId + "; Path=/");
-        }
+        Http11Session session = SessionManager.createSession();
+        session.setAttribute("user", user);
+
+        response.sendRedirect("/index.html");
     }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/RegisterController.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/RegisterController.java
@@ -17,6 +17,12 @@ public class RegisterController extends AbstractController {
     private static final Logger log = LoggerFactory.getLogger(RegisterController.class);
 
     @Override
+    protected void doGet(Http11Request request, Http11Response response) throws Exception {
+        response.putHeader("Content-Type", "text/html; charset=utf-8");
+        response.putBody(response.readFileFromClasspath("static/register.html"));
+    }
+
+    @Override
     protected void doPost(Http11Request request, Http11Response response) throws Exception {
         final User user = new User(request.getParam("account"), request.getParam("password"), request.getParam("email"));
         InMemoryUserRepository.save(user);
@@ -24,12 +30,6 @@ public class RegisterController extends AbstractController {
         createSessionAndSetCookie(user, request, response);
         response.putStatusLine("HTTP/1.1 302 Found");
         response.putHeader("Location", "/index.html");
-    }
-
-    @Override
-    protected void doGet(Http11Request request, Http11Response response) throws Exception {
-        response.putHeader("Content-Type", "text/html; charset=utf-8");
-        response.putBody(response.readFileFromClasspath("static/register.html"));
     }
 
     private void createSessionAndSetCookie(final User user, final Http11Request request, final Http11Response response) {

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/RegisterController.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/RegisterController.java
@@ -16,7 +16,7 @@ public class RegisterController extends AbstractController {
     @Override
     protected void doGet(Http11Request request, Http11Response response) throws Exception {
         response.putHeader("Content-Type", "text/html; charset=utf-8");
-        response.putBody(response.readFileFromClasspath("static/register.html"));
+        response.readFileFromClasspath("static/register.html");
     }
 
     @Override

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/RegisterController.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/RegisterController.java
@@ -1,0 +1,46 @@
+package org.apache.coyote.http11.controller;
+
+import com.techcourse.db.InMemoryUserRepository;
+import com.techcourse.model.User;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.coyote.http11.Http11Cookie;
+import org.apache.coyote.http11.Http11Request;
+import org.apache.coyote.http11.Http11Response;
+import org.apache.coyote.http11.Http11Session;
+import org.apache.coyote.http11.SessionManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RegisterController extends AbstractController {
+
+    private static final Logger log = LoggerFactory.getLogger(RegisterController.class);
+
+    @Override
+    protected void doPost(Http11Request request, Http11Response response) throws Exception {
+        final User user = new User(request.getParam("account"), request.getParam("password"), request.getParam("email"));
+        InMemoryUserRepository.save(user);
+        log.info("User saved: {}", user);
+        createSessionAndSetCookie(user, request, response);
+        response.putStatusLine("HTTP/1.1 302 Found");
+        response.putHeader("Location", "/index.html");
+    }
+
+    @Override
+    protected void doGet(Http11Request request, Http11Response response) throws Exception {
+        response.putHeader("Content-Type", "text/html; charset=utf-8");
+        response.putBody(response.readFileFromClasspath("static/register.html"));
+    }
+
+    private void createSessionAndSetCookie(final User user, final Http11Request request, final Http11Response response) {
+        final Http11Cookie cookie = request.getCookie();
+        if (cookie.isNotContainsSessionId() || !SessionManager.getInstance().containsSession(cookie.getSessionId())) {
+            final String sessionId = UUID.randomUUID().toString();
+            final Http11Session session = new Http11Session(sessionId);
+            session.setAttribute("user", user);
+            SessionManager.getInstance().add(session);
+            // TODO: CookieSecurityConfig를 통한 HttpOnly 기본, Secure/SameSite 설정 전략 등 고려하기
+            response.putHeader("Set-Cookie", "JSESSIONID=" + sessionId + "; Path=/");
+        }
+    }
+}

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/RegisterController.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/RegisterController.java
@@ -27,7 +27,7 @@ public class RegisterController extends AbstractController {
 
         Http11Session session = SessionManager.createSession();
         session.setAttribute("user", user);
-
+        response.putHeader("Set-Cookie", "JSESSIONID=" + session.getId() + "; Path=/");
         response.sendRedirect("/index.html");
     }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/ResourceController.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/ResourceController.java
@@ -1,0 +1,25 @@
+package org.apache.coyote.http11.controller;
+
+import org.apache.coyote.http11.Http11Request;
+import org.apache.coyote.http11.Http11Response;
+import org.apache.coyote.http11.MediaType;
+import org.apache.coyote.http11.exception.Http11ParseException;
+
+public class ResourceController extends AbstractController {
+
+    @Override
+    protected void doGet(final Http11Request request, final Http11Response response) throws Http11ParseException {
+        final String path = request.getPath();
+        final String resource = response.readFileFromClasspath("static" + path);
+
+        if (resource.isEmpty()) {
+            response.putStatusLine("HTTP/1.1 404 Not Found");
+            response.putHeader("Content-Type", "text/html; charset=utf-8");
+            response.putBody(response.readFileFromClasspath("static/404.html"));
+            return;
+        }
+
+        response.putHeader("Content-Type", MediaType.detectMimeType(path));
+        response.putBody(resource);
+    }
+}

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/ResourceController.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/ResourceController.java
@@ -2,6 +2,7 @@ package org.apache.coyote.http11.controller;
 
 import org.apache.coyote.http11.Http11Request;
 import org.apache.coyote.http11.Http11Response;
+import org.apache.coyote.http11.Http11Status;
 import org.apache.coyote.http11.MediaType;
 import org.apache.coyote.http11.exception.Http11ParseException;
 
@@ -13,12 +14,9 @@ public class ResourceController extends AbstractController {
         final String resource = response.readFileFromClasspath("static" + path);
 
         if (resource.isEmpty()) {
-            response.putStatusLine("HTTP/1.1 404 Not Found");
-            response.putHeader("Content-Type", "text/html; charset=utf-8");
-            response.putBody(response.readFileFromClasspath("static/404.html"));
+            response.sendError(Http11Status.NOT_FOUND);
             return;
         }
-
         response.putHeader("Content-Type", MediaType.detectMimeType(path));
         response.putBody(resource);
     }

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/ResourceController.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/ResourceController.java
@@ -2,22 +2,14 @@ package org.apache.coyote.http11.controller;
 
 import org.apache.coyote.http11.Http11Request;
 import org.apache.coyote.http11.Http11Response;
-import org.apache.coyote.http11.Http11Status;
 import org.apache.coyote.http11.MediaType;
-import org.apache.coyote.http11.exception.Http11ParseException;
 
 public class ResourceController extends AbstractController {
 
     @Override
-    protected void doGet(final Http11Request request, final Http11Response response) throws Http11ParseException {
+    protected void doGet(final Http11Request request, final Http11Response response) {
         final String path = request.getPath();
-        final String resource = response.readFileFromClasspath("static" + path);
-
-        if (resource.isEmpty()) {
-            response.sendError(Http11Status.NOT_FOUND);
-            return;
-        }
+        response.readFileFromClasspath("static" + path);
         response.putHeader("Content-Type", MediaType.detectMimeType(path));
-        response.putBody(resource);
     }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/ResourceController.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/ResourceController.java
@@ -7,7 +7,7 @@ import org.apache.coyote.http11.MediaType;
 public class ResourceController extends AbstractController {
 
     @Override
-    protected void doGet(final Http11Request request, final Http11Response response) {
+    protected void doGet(final Http11Request request, final Http11Response response) throws Exception {
         final String path = request.getPath();
         response.readFileFromClasspath("static" + path);
         response.putHeader("Content-Type", MediaType.detectMimeType(path));

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/util/ControllerMapper.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/util/ControllerMapper.java
@@ -15,10 +15,10 @@ public class ControllerMapper {
     private static final Map<String, Controller> CONTROLLERS = new HashMap<>();
 
     static {
-        CONTROLLERS.put("/index.html", new IndexController());
+        CONTROLLERS.put("/", new IndexController());
+        CONTROLLERS.put("/index", new IndexController());
         CONTROLLERS.put("/register", new RegisterController());
         CONTROLLERS.put("/login", new LoginController());
-        CONTROLLERS.put("/login.html", new LoginController());
         CONTROLLERS.put("/logout", new LogoutController());
     }
 

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/util/ControllerMapper.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/util/ControllerMapper.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import org.apache.coyote.http11.controller.Controller;
 import org.apache.coyote.http11.controller.IndexController;
 import org.apache.coyote.http11.controller.LoginController;
+import org.apache.coyote.http11.controller.LogoutController;
 import org.apache.coyote.http11.controller.RegisterController;
 
 public class ControllerMapper {
@@ -16,6 +17,7 @@ public class ControllerMapper {
         CONTROLLERS.put("/register", new RegisterController());
         CONTROLLERS.put("/login", new LoginController());
         CONTROLLERS.put("/login.html", new LoginController());
+        CONTROLLERS.put("/logout", new LogoutController());
     }
 
     public static Controller getController(final String path) {

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/util/ControllerMapper.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/util/ControllerMapper.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.coyote.http11.controller.Controller;
 import org.apache.coyote.http11.controller.IndexController;
+import org.apache.coyote.http11.controller.LoginController;
 import org.apache.coyote.http11.controller.RegisterController;
 
 public class ControllerMapper {
@@ -13,6 +14,8 @@ public class ControllerMapper {
     static {
         CONTROLLERS.put("/index.html", new IndexController());
         CONTROLLERS.put("/register", new RegisterController());
+        CONTROLLERS.put("/login", new LoginController());
+        CONTROLLERS.put("/login.html", new LoginController());
     }
 
     public static Controller getController(final String path) {

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/util/ControllerMapper.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/util/ControllerMapper.java
@@ -7,9 +7,11 @@ import org.apache.coyote.http11.controller.IndexController;
 import org.apache.coyote.http11.controller.LoginController;
 import org.apache.coyote.http11.controller.LogoutController;
 import org.apache.coyote.http11.controller.RegisterController;
+import org.apache.coyote.http11.controller.ResourceController;
 
 public class ControllerMapper {
 
+    private static final Controller RESOURCE_CONTROLLER = new ResourceController();
     private static final Map<String, Controller> CONTROLLERS = new HashMap<>();
 
     static {
@@ -21,6 +23,6 @@ public class ControllerMapper {
     }
 
     public static Controller getController(final String path) {
-        return CONTROLLERS.getOrDefault(path, null);
+        return CONTROLLERS.getOrDefault(path, RESOURCE_CONTROLLER);
     }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/util/ControllerMapper.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/util/ControllerMapper.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.coyote.http11.controller.Controller;
 import org.apache.coyote.http11.controller.IndexController;
+import org.apache.coyote.http11.controller.RegisterController;
 
 public class ControllerMapper {
 
@@ -11,6 +12,7 @@ public class ControllerMapper {
 
     static {
         CONTROLLERS.put("/index.html", new IndexController());
+        CONTROLLERS.put("/register", new RegisterController());
     }
 
     public static Controller getController(final String path) {

--- a/tomcat/src/main/java/org/apache/coyote/http11/controller/util/ControllerMapper.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/controller/util/ControllerMapper.java
@@ -1,0 +1,19 @@
+package org.apache.coyote.http11.controller.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.coyote.http11.controller.Controller;
+import org.apache.coyote.http11.controller.IndexController;
+
+public class ControllerMapper {
+
+    private static final Map<String, Controller> CONTROLLERS = new HashMap<>();
+
+    static {
+        CONTROLLERS.put("/index.html", new IndexController());
+    }
+
+    public static Controller getController(final String path) {
+        return CONTROLLERS.getOrDefault(path, null);
+    }
+}

--- a/tomcat/src/main/java/org/apache/coyote/http11/exception/Http11ParseException.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/exception/Http11ParseException.java
@@ -1,4 +1,4 @@
-package org.apache.coyote.http11;
+package org.apache.coyote.http11.exception;
 
 public class Http11ParseException extends Exception {
 

--- a/tomcat/src/main/java/org/apache/coyote/http11/exception/ParseError.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/exception/ParseError.java
@@ -3,7 +3,8 @@ package org.apache.coyote.http11.exception;
 public enum ParseError {
 
     INVALID_REQUEST_LINE(400, "Invalid request line"),
-    INVALID_HTTP_METHOD(400, "Invalid http method");
+    INVALID_HTTP_METHOD(400, "Invalid http method"),
+    INVALID_STATUS_CODE(400, "Invalid status code format");
 
     private final int statusCode;
     private final String message;

--- a/tomcat/src/main/java/org/apache/coyote/http11/exception/ParseError.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/exception/ParseError.java
@@ -1,4 +1,4 @@
-package org.apache.coyote.http11;
+package org.apache.coyote.http11.exception;
 
 public enum ParseError {
 

--- a/tomcat/src/main/java/org/apache/coyote/http11/exception/util/ErrorResourceMapper.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/exception/util/ErrorResourceMapper.java
@@ -1,0 +1,20 @@
+package org.apache.coyote.http11.exception.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ErrorResourceMapper {
+
+    private static final Map<Integer, String> RESOURCES = new HashMap<>();
+
+    static {
+        RESOURCES.put(400, "/static/400.html");
+        RESOURCES.put(401, "/static/401.html");
+        RESOURCES.put(404, "/static/404.html");
+        RESOURCES.put(500, "/static/500.html");
+    }
+
+    public static String getResource(final int code) {
+        return RESOURCES.getOrDefault(code, "/static/500.html");
+    }
+}

--- a/tomcat/src/test/java/org/apache/coyote/http11/Http11ProcessorTest.java
+++ b/tomcat/src/test/java/org/apache/coyote/http11/Http11ProcessorTest.java
@@ -1,37 +1,16 @@
 package org.apache.coyote.http11;
 
-import org.junit.jupiter.api.Test;
-import support.StubSocket;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+import support.StubSocket;
 
 class Http11ProcessorTest {
-
-    @Test
-    void process() {
-        // given
-        final var socket = new StubSocket();
-        final var processor = new Http11Processor(socket);
-
-        // when
-        processor.process(socket);
-
-        // then
-        var expected = String.join("\r\n",
-                "HTTP/1.1 200 OK",
-                "Content-Type: text/html;charset=utf-8",
-                "Content-Length: 12",
-                "",
-                "Hello world!");
-
-        assertThat(socket.output()).isEqualTo(expected);
-    }
 
     @Test
     void index() throws IOException {
@@ -59,35 +38,6 @@ class Http11ProcessorTest {
                 "Content-Length: " + body.getBytes(StandardCharsets.UTF_8).length + "\r\n" +
                 "\r\n" +
                 body;
-
-        assertThat(socket.output()).isEqualTo(expected);
-    }
-
-    @Test
-    void malformed_request_line_results_in_400() throws IOException {
-        final String httpRequest = String.join("\r\n",
-                "GET",
-                "Host: localhost:8080",
-                "",
-                "");
-
-        final var socket = new StubSocket(httpRequest);
-        final var processor = new Http11Processor(socket);
-
-        // when
-        processor.process(socket);
-
-        // then
-        final URL resource = getClass().getClassLoader().getResource("static/400.html");
-        final String body = Files.readString(new File(resource.getFile()).toPath())
-                .replace("\r\n", "\n").replace("\n", "\r\n");
-
-        String expected = String.join("\r\n",
-                "HTTP/1.1 400 Bad Request",
-                "Content-Type: text/html;charset=utf-8",
-                "Content-Length: " + body.getBytes(StandardCharsets.UTF_8).length,
-                "",
-                body);
 
         assertThat(socket.output()).isEqualTo(expected);
     }

--- a/tomcat/src/test/java/org/apache/coyote/http11/Http11ProcessorTest.java
+++ b/tomcat/src/test/java/org/apache/coyote/http11/Http11ProcessorTest.java
@@ -41,4 +41,48 @@ class Http11ProcessorTest {
 
         assertThat(socket.output()).isEqualTo(expected);
     }
+
+    @Test
+    void method_not_allowed_test() {
+        // given
+        final String httpRequest= String.join("\r\n",
+                "PUT /index HTTP/1.1",
+                "Host: localhost:8080",
+                "Connection: keep-alive",
+                "",
+                "");
+
+        final var socket = new StubSocket(httpRequest);
+        final Http11Processor processor = new Http11Processor(socket);
+
+        // when
+        processor.process(socket);
+
+        // then
+        // Expect 405 Method Not Allowed without body
+        var expectedStart = "HTTP/1.1 405 Method Not Allowed\r\n";
+        assertThat(socket.output()).startsWith(expectedStart);
+    }
+
+    @Test
+    void post_to_index_is_method_not_allowed() {
+        // given
+        final String httpRequest= String.join("\r\n",
+                "POST /index HTTP/1.1",
+                "Host: localhost:8080",
+                "Connection: keep-alive",
+                "Content-Length: 0",
+                "",
+                "");
+
+        final var socket = new StubSocket(httpRequest);
+        final Http11Processor processor = new Http11Processor(socket);
+
+        // when
+        processor.process(socket);
+
+        // then
+        var expectedStart = "HTTP/1.1 405 Method Not Allowed\r\n";
+        assertThat(socket.output()).startsWith(expectedStart);
+    }
 }


### PR DESCRIPTION
안녕하세요 코기~! 🙋 
리팩토링에 욕심이 생겨서.. 자꾸 이것저것 시도하다가 늦어졌네요. 
잘부탁드립니다 🙇 

1. Http11Request
    - inputstream 요청 정보를 파싱하여 저장합니다. 
2. Http11Response 
    - outputstream을 활용해 sendRedirect, sendError 등으로 응답합니다.
3. AbstractController, ControllerMapper 및 자식 구현체 
    - 요청 경로를 바탕으로, 적절한 컨트롤러에 연결하여 비즈니스 로직을 수행합니다.

---

step2 코멘트 답변

1. Http11Cookie가 어떤 필드를 사용할지는 객체를 사용하는 쪽에서 결정하는 것이 아닌가?

와.. 대박입니다. 인정합니다!
`containsSessionId()` 를 초기의 구현한 의도는 앞서 코기가 말씀해주신대로 쿠키 클래스에게 직접 물어보려는 의도였습니다.
코멘트의 내용처럼 Http11Cookie의 역할이 뭘까에 대해 고민했는데, 요청 헤더를 통해 들어온 값들을 key-value 형식으로 저장해주는, 
저장소를 기호에 맞게 확장한 역할에 더욱 가깝다고 생각이 들었습니다. 

차라리 maxage 등의 쿠키의 특성에 관한 정보면 isExpired() 등의 메서드를 만들어 주는 것이 좋아보이는데, 
쿠키의 입장에선 JSESSIONID도 여러 저장 데이터 중 하나에 가깝다고 생각이 들어, 
오히려 `containsSessionId()` 등을 사용하는 것이 더 무례한 것 같다는 생각이 드네요!

2. Request를 파싱하는 객체

비슷한 파싱 로직이 여러곳에서 쓰이면 별도의 유틸 클래스를 고려할 수 있겠지만, inputstream에서 각각의 정보를(path, headers) 파싱하는 로직은 Http11Request의 책임이라고 생각하고, 별도의 객체를 추출해 얻을 수 있는 이점(중복코드 제거 등) 이 지금 미션에서는 크지 않다고 생각해요! 코기의 의견이 궁금합니다.   

3. SessionManager에서 SESSION 필드가 static인데도 불구하고 싱글톤 사용이유

필드가 static으로 선언되었기 때문에 미션에서 요구하는 기능을 구현하는데는 무리가 없었지만, 
SessionManager 객체 자체가 두번이상 생성되는 것을 막기 위해서 싱글톤이 이점이 더 크다고 생각했습니다.