### PR TITLE
[4단계 - 동시성 확장하기] 머피(송제용) 미션 제출합니다. 

### DIFF
--- a/tomcat/src/main/java/com/techcourse/controller/GreetingController.java
+++ b/tomcat/src/main/java/com/techcourse/controller/GreetingController.java
@@ -4,17 +4,19 @@ import org.apache.catalina.controller.AbstractController;
 import org.apache.coyote.request.HttpRequest;
 import org.apache.coyote.response.HttpResponse;
 
+import java.nio.charset.StandardCharsets;
+
 public class GreetingController extends AbstractController {
 
     @Override
     protected HttpResponse doGet(final HttpRequest request) {
-        final var body = "Hello world!".getBytes();
+        final var body = "Hello world!";
 
         return HttpResponse.builder()
                 .protocol(request.getProtocol())
                 .status(200, "OK")
                 .contentType("text/plain;charset=utf-8")
-                .body(body)
+                .body(body.getBytes(StandardCharsets.UTF_8))
                 .build();
     }
 }

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -1,6 +1,7 @@
 package org.apache.catalina.connector;
 
 import org.apache.coyote.http11.Http11Processor;
+import org.apache.util.CustomTaskQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -8,6 +9,9 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 public class Connector implements Runnable {
 
@@ -15,31 +19,58 @@ public class Connector implements Runnable {
 
     private static final int DEFAULT_PORT = 8080;
     private static final int DEFAULT_ACCEPT_COUNT = 100;
+    private static final int DEFAULT_CORE_THREADS = 10;
+    private static final int DEFAULT_MAX_THREADS = 200;
+    private static final int DEFAULT_QUEUE_SIZE = 100;
+    private static final int SHUTDOWN_TIMEOUT = 60;
 
     private final ServerSocket serverSocket;
-    private boolean stopped;
+    private final ExecutorService executorService;
+    private volatile boolean stopped;
 
     public Connector() {
-        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT);
+        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT, DEFAULT_CORE_THREADS, DEFAULT_MAX_THREADS, DEFAULT_QUEUE_SIZE);
     }
 
-    public Connector(final int port, final int acceptCount) {
+    public Connector(
+            final int port,
+            final int acceptCount,
+            final int coreThreads,
+            final int maxThreads,
+            final int queueSize
+    ) {
         this.serverSocket = createServerSocket(port, acceptCount);
+        this.executorService = createThreadPool(coreThreads, maxThreads, queueSize);
         this.stopped = false;
     }
 
     private ServerSocket createServerSocket(final int port, final int acceptCount) {
         try {
-            final int checkedPort = checkPort(port);
-            final int checkedAcceptCount = checkAcceptCount(acceptCount);
+            final var checkedPort = checkPort(port);
+            final var checkedAcceptCount = checkAcceptCount(acceptCount);
+
             return new ServerSocket(checkedPort, checkedAcceptCount);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
     }
 
+    private ExecutorService createThreadPool(final int coreThreads, final int maxThreads, final int queueSize) {
+        final var queue = new CustomTaskQueue(queueSize);
+        final var executor = new ThreadPoolExecutor(
+                coreThreads,
+                maxThreads,
+                60L, TimeUnit.SECONDS,
+                queue,
+                new ThreadPoolExecutor.AbortPolicy()
+        );
+        queue.setParent(executor);
+
+        return executor;
+    }
+
     public void start() {
-        var thread = new Thread(this);
+        final var thread = new Thread(this);
         thread.setDaemon(true);
         thread.start();
         stopped = false;
@@ -48,7 +79,6 @@ public class Connector implements Runnable {
 
     @Override
     public void run() {
-        // 클라이언트가 연결될때까지 대기한다.
         while (!stopped) {
             connect();
         }
@@ -58,7 +88,9 @@ public class Connector implements Runnable {
         try {
             process(serverSocket.accept());
         } catch (IOException e) {
-            log.error(e.getMessage(), e);
+            if (!stopped) {
+                log.error("Error accepting connection", e);
+            }
         }
     }
 
@@ -66,8 +98,8 @@ public class Connector implements Runnable {
         if (connection == null) {
             return;
         }
-        var processor = new Http11Processor(connection);
-        new Thread(processor).start();
+        final var processor = new Http11Processor(connection);
+        executorService.execute(processor);
     }
 
     public void stop() {
@@ -86,6 +118,7 @@ public class Connector implements Runnable {
         if (port < MIN_PORT || MAX_PORT < port) {
             return DEFAULT_PORT;
         }
+        
         return port;
     }
 

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -106,8 +106,20 @@ public class Connector implements Runnable {
         stopped = true;
         try {
             serverSocket.close();
+            executorService.shutdown();
+
+            if (!executorService.awaitTermination(SHUTDOWN_TIMEOUT, TimeUnit.SECONDS)) {
+                log.warn("Forcing shutdown - some requests did not finish in time");
+                executorService.shutdownNow();
+            }
+            log.info("Connector stopped gracefully");
         } catch (IOException e) {
-            log.error(e.getMessage(), e);
+            log.error("Error closing server socket", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread()
+                    .interrupt();
+            log.warn("Shutdown interrupted, forcing shutdown now");
+            executorService.shutdownNow();
         }
     }
 

--- a/tomcat/src/main/java/org/apache/catalina/controller/AbstractController.java
+++ b/tomcat/src/main/java/org/apache/catalina/controller/AbstractController.java
@@ -3,6 +3,8 @@ package org.apache.catalina.controller;
 import org.apache.coyote.request.HttpRequest;
 import org.apache.coyote.response.HttpResponse;
 
+import java.nio.charset.StandardCharsets;
+
 public abstract class AbstractController implements Controller {
 
     @Override
@@ -19,7 +21,7 @@ public abstract class AbstractController implements Controller {
                 .protocol(request.getProtocol())
                 .status(405, "Method Not Allowed")
                 .contentType("text/plain;charset=utf-8")
-                .body("Method Not Allowed".getBytes())
+                .body("Method Not Allowed".getBytes(StandardCharsets.UTF_8))
                 .build();
     }
 
@@ -28,7 +30,7 @@ public abstract class AbstractController implements Controller {
                 .protocol(request.getProtocol())
                 .status(405, "Method Not Allowed")
                 .contentType("text/plain;charset=utf-8")
-                .body("Method Not Allowed".getBytes())
+                .body("Method Not Allowed".getBytes(StandardCharsets.UTF_8))
                 .build();
     }
 
@@ -37,7 +39,7 @@ public abstract class AbstractController implements Controller {
                 .protocol(request.getProtocol())
                 .status(405, "Method Not Allowed")
                 .contentType("text/plain;charset=utf-8")
-                .body("Method Not Allowed".getBytes())
+                .body("Method Not Allowed".getBytes(StandardCharsets.UTF_8))
                 .build();
     }
 }

--- a/tomcat/src/main/java/org/apache/catalina/controller/RequestAdapter.java
+++ b/tomcat/src/main/java/org/apache/catalina/controller/RequestAdapter.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 
 public class RequestAdapter {
 
@@ -53,7 +54,7 @@ public class RequestAdapter {
                     .protocol(request.getProtocol())
                     .status(405, "Method Not Allowed")
                     .contentType("text/plain;charset=utf-8")
-                    .body("Method Not Allowed".getBytes())
+                    .body("Method Not Allowed".getBytes(StandardCharsets.UTF_8))
                     .build();
         }
 

--- a/tomcat/src/main/java/org/apache/catalina/session/SimpleHttpSession.java
+++ b/tomcat/src/main/java/org/apache/catalina/session/SimpleHttpSession.java
@@ -17,7 +17,7 @@ public class SimpleHttpSession implements HttpSession {
     private final String id;
     private final Map<String, Object> attributes;
     private final AtomicBoolean valid = new AtomicBoolean(true);
-    private final AtomicBoolean isNew = new AtomicBoolean(true);
+    private volatile boolean isNew = true;
 
     public SimpleHttpSession(final String id, final Map<String, Object> attributes) {
         Objects.requireNonNull(id, "id must not be null");
@@ -75,13 +75,13 @@ public class SimpleHttpSession implements HttpSession {
     @Override
     public boolean isNew() {
         checkValid();
-        return isNew.get();
+        return isNew;
     }
 
     void setNew(final boolean value) {
-        this.isNew.set(value);
+        this.isNew = value;
     }
-    
+
     private void checkValid() {
         if (!valid.get()) {
             throw new IllegalStateException("세션이 이미 무효화되었습니다.");

--- a/tomcat/src/main/java/org/apache/util/CustomTaskQueue.java
+++ b/tomcat/src/main/java/org/apache/util/CustomTaskQueue.java
@@ -1,0 +1,49 @@
+package org.apache.util;
+
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * Tomcat TaskQueue 유사 구현
+ * - 큐보다 스레드 확장을 우선시
+ * - idle thread 있으면 큐에 넣음
+ * - maxThreads 도달 시에만 큐 사용
+ */
+public class CustomTaskQueue extends LinkedBlockingQueue<Runnable> {
+
+    private volatile ThreadPoolExecutor parent;
+
+    public CustomTaskQueue(final int capacity) {
+        super(capacity);
+    }
+
+    public void setParent(final ThreadPoolExecutor parent) {
+        this.parent = parent;
+    }
+
+    @Override
+    public boolean offer(final Runnable runnable) {
+        if (parent == null) {
+            return super.offer(runnable);
+        }
+
+        final var poolSize = parent.getPoolSize();
+        final var maxPoolSize = parent.getMaximumPoolSize();
+
+        if (poolSize == maxPoolSize) {
+            return super.offer(runnable);
+        }
+
+        if (parent.getQueue()
+                .isEmpty()
+                && parent.getActiveCount() < poolSize) {
+            return super.offer(runnable);
+        }
+
+        if (poolSize < maxPoolSize) {
+            return false;
+        }
+
+        return super.offer(runnable);
+    }
+}

--- a/tomcat/src/test/java/org/apache/util/CustomTaskQueueTest.java
+++ b/tomcat/src/test/java/org/apache/util/CustomTaskQueueTest.java
@@ -1,0 +1,93 @@
+package org.apache.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CustomTaskQueueTest {
+
+    @Test
+    void customTaskQueue는_maxThreads까지_스레드를_늘린다() throws InterruptedException {
+        // given
+        final int core = 1;
+        final int max = 3;
+        final int queueSize = 10;
+
+        final var queue = new CustomTaskQueue(queueSize);
+        final var executor = new ThreadPoolExecutor(
+                core,
+                max,
+                60L, TimeUnit.SECONDS,
+                queue,
+                new ThreadPoolExecutor.AbortPolicy()
+        );
+        queue.setParent(executor);
+
+        // when
+        for (int i = 0; i < 5; i++) {
+            executor.execute(() -> {
+                try {
+                    Thread.sleep(500); // 일부러 오래 걸리게
+                } catch (InterruptedException ignored) {
+                }
+            });
+        }
+
+        // then
+        Thread.sleep(100); // 스레드가 늘어날 시간을 조금 줌
+
+        System.out.println("Active count = " + executor.getActiveCount());
+        System.out.println("Pool size   = " + executor.getPoolSize());
+        System.out.println("Queue size  = " + executor.getQueue()
+                .size());
+
+        // CustomTaskQueue 덕분에, 큐에 넣기 전에 max까지 스레드를 늘림
+        assertThat(executor.getPoolSize()).isEqualTo(max);
+        assertThat(executor.getQueue()
+                .size()).isEqualTo(2); // 나머지는 큐에
+    }
+
+    @Test
+    void 기본_LinkedBlockingQueue는_큐부터_쌓는다() throws InterruptedException {
+        // given
+        final int core = 1;
+        final int max = 3;
+        final int queueSize = 10;
+
+        final var queue = new LinkedBlockingQueue<Runnable>(queueSize);
+        final var executor = new ThreadPoolExecutor(
+                core,
+                max,
+                60L, TimeUnit.SECONDS,
+                queue,
+                new ThreadPoolExecutor.AbortPolicy()
+        );
+
+        // when
+        for (int i = 0; i < 5; i++) {
+            executor.execute(() -> {
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException ignored) {
+                }
+            });
+        }
+
+        // then
+        Thread.sleep(100);
+
+        System.out.println("Active count = " + executor.getActiveCount());
+        System.out.println("Pool size   = " + executor.getPoolSize());
+        System.out.println("Queue size  = " + executor.getQueue()
+                .size());
+
+        // 기본 정책: core 이상은 큐에 먼저 쌓음
+        assertThat(executor.getPoolSize()).isEqualTo(core);
+        assertThat(executor.getQueue()
+                .size()).isGreaterThan(0);
+    }
+}


### PR DESCRIPTION
안녕하세요, 피글렛, 머피입니다! 벌써 마지막 스텝이군요 

시간이 참 빠르네요... ㅎㅎ  
음.. step4가 금방 끝날 것 같다고 말씀드렸지만 생각보다 오래 걸렸네요 ㅠㅠ  

왜 오래 걸린지는 지금부터 설명드려보겠습니다!! 아마 피글렛의 학습에도 도움이 될 것 같아 자세히 말씀드려 볼게요!!

먼저 저는 이번 요구사항에 집중했습니다!!

> 이 단계의 요구사항은 자바가 제공하는 API를 활용하면 쉽게 구현할 수 있다.  
> 이 단계의 핵심 학습 목표는 요구사항을 만족하는 것보다 WAS에서 Thread Pool의 동작 원리를 이해하는 것이 더 중요하다.  
> 힌트와 학습 테스트를 진행해 보면서 WAS의 Thread Pool 동작 원리를 이해할 것을 추천한다.

그래서 저는 저희가 이번에 "퀘스트 3: Spring Boot에서 WAS 스레드 풀 설정하기"에서 학습한 톰캣의 스레드 풀에 집중했는데요!  

먼저 `java.util.concurrent.ThreadPoolExecutor` 와 `org.apache.tomcat.util.threads.ThreadPoolExecutor` 의 차이점부터 말씀드려보겠습니다!!  

- `java.util.concurrent.ThreadPoolExecutor`는 **표준 JDK 구현**으로, 작업이 들어올 때 `corePoolSize`까지는 스레드를 늘리고, 그 이후에는 **workQueue**에 태스크를 쌓습니다. 큐가 가득 차야 비로소 `maximumPoolSize`까지 초과 스레드를 생성합니다.  
- 반면, 톰캣의 `ThreadPoolExecutor`는 **TaskQueue**라는 자체 구현 큐를 사용합니다. 이 큐는 단순히 `offer()`를 수행하는 대신, 아직 초과 스레드를 생성할 여지가 있다면 큐에 넣는 것을 거부하고 스레드 생성을 유도합니다. 즉, **큐 적재보다 초과 스레드 생성이 우선**이라는 점이 큰 차이입니다.  

이 덕분에, JDK 기본 구현에서는 큐가 무한대라면 절대 `maximumPoolSize`까지 늘어나지 않지만, 톰캣 방식에서는 상황에 따라 초과 스레드가 생성되어 순간적인 폭주 트래픽을 더 잘 처리할 수 있습니다.  

저는 이 차이를 직접 체험해보고자 `java.util.concurrent.ThreadPoolExecutor`를 확장해 톰캣의 동작을 흉내 내보았습니다. 그 과정에서 등장한 클래스가 바로 `CustomTaskQueue`입니다.  

`CustomTaskQueue`는 내부적으로 `ThreadPoolExecutor`와 협력하면서, 단순 큐잉 대신 **스레드 확장을 먼저 시도한 뒤 큐잉**하는 방식을 반영했습니다.  

관련된 테스트는 `CustomTaskQueueTest`에서 확인하실 수 있습니다! 실제로 큐에 태스크가 들어갈 때와 스레드가 추가로 늘어나는 상황을 비교해보면서 학습할 수 있도록 작성했습니다.  

저는 톰캣이 왜 이런 방식을 채택했을까 생각해봤는데, 아무래도 **웹 서버 특성상 순간적인 요청 폭주를 견디는 능력**이 중요하기 때문이라고 보았습니다. 단순히 큐에 쌓아두기보다, 가능하다면 초과 스레드를 활용해서 최대한 즉시 처리하려는 설계 철학이 반영된 것 같습니다.  

긴 글 읽어주셔서 감사합니다!!  
이번에도 편하실 때 리뷰 진행해주시면 됩니다!! 
아마 오늘이 또 새로운 미션 시작이라 주말에 해주시는 것도 나쁘지 않겠네요 ㅎㅎ  

마지막까지 잘 부탁드립니다! 감사합니다
