### PR TITLE
 [4단계 - 동시성 확장하기] 새로이(강철원) 미션 제출합니다. 

### DIFF
--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -1,5 +1,9 @@
 package org.apache.catalina.connector;
 
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import org.apache.coyote.http11.Http11Processor;
 import org.apache.catalina.handler.DispatcherHandler;
 import org.slf4j.Logger;
@@ -16,19 +20,29 @@ public class Connector implements Runnable {
 
     private static final int DEFAULT_PORT = 8080;
     private static final int DEFAULT_ACCEPT_COUNT = 100;
+    private static final int DEFAULT_MAX_THREADS = 200;
 
     private final ServerSocket serverSocket;
-    private boolean stopped;
     private final DispatcherHandler dispatcher;
+    private final ExecutorService executorService;
+    private boolean stopped;
 
     public Connector(DispatcherHandler dispatcher) {
-        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT, dispatcher);
+        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT, DEFAULT_MAX_THREADS, dispatcher);
     }
 
-    public Connector(final int port, final int acceptCount, DispatcherHandler dispatcher) {
+    public Connector(final int port, final int acceptCount, final int maxThreads, DispatcherHandler dispatcher) {
         this.serverSocket = createServerSocket(port, acceptCount);
         this.stopped = false;
         this.dispatcher = dispatcher;
+        this.executorService = new ThreadPoolExecutor(
+                maxThreads,
+                maxThreads,
+                60L, TimeUnit.SECONDS,
+                new ArrayBlockingQueue<>(acceptCount),
+                new ThreadPoolExecutor.AbortPolicy()
+
+        );
     }
 
     private ServerSocket createServerSocket(final int port, final int acceptCount) {
@@ -70,7 +84,7 @@ public class Connector implements Runnable {
             return;
         }
         var processor = new Http11Processor(connection, dispatcher);
-        new Thread(processor).start();
+        executorService.submit(processor);
     }
 
     public void stop() {
@@ -79,6 +93,8 @@ public class Connector implements Runnable {
             serverSocket.close();
         } catch (IOException e) {
             log.error(e.getMessage(), e);
+        } finally {
+            executorService.shutdown();
         }
     }
 

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -2,6 +2,7 @@ package org.apache.catalina.connector;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.apache.coyote.http11.Http11Processor;
@@ -40,7 +41,7 @@ public class Connector implements Runnable {
                 corePoolSize,
                 maxThreads,
                 60L, TimeUnit.SECONDS,
-                new ArrayBlockingQueue<>(acceptCount),
+                new LinkedBlockingQueue<Runnable>(),
                 new ThreadPoolExecutor.AbortPolicy()
         );
     }

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -21,6 +21,7 @@ public class Connector implements Runnable {
     private static final int DEFAULT_PORT = 8080;
     private static final int DEFAULT_ACCEPT_COUNT = 100;
     private static final int DEFAULT_MAX_THREADS = 200;
+    private static final int CORE_PULL_SIZE = 10;
 
     private final ServerSocket serverSocket;
     private final DispatcherHandler dispatcher;
@@ -28,20 +29,19 @@ public class Connector implements Runnable {
     private boolean stopped;
 
     public Connector(DispatcherHandler dispatcher) {
-        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT, DEFAULT_MAX_THREADS, dispatcher);
+        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT, CORE_PULL_SIZE, DEFAULT_MAX_THREADS, dispatcher);
     }
 
-    public Connector(final int port, final int acceptCount, final int maxThreads, DispatcherHandler dispatcher) {
+    public Connector(final int port, final int acceptCount, final int corePoolSize, final int maxThreads, DispatcherHandler dispatcher) {
         this.serverSocket = createServerSocket(port, acceptCount);
         this.stopped = false;
         this.dispatcher = dispatcher;
         this.executorService = new ThreadPoolExecutor(
-                maxThreads,
+                corePoolSize,
                 maxThreads,
                 60L, TimeUnit.SECONDS,
                 new ArrayBlockingQueue<>(acceptCount),
                 new ThreadPoolExecutor.AbortPolicy()
-
         );
     }
 

--- a/tomcat/src/main/java/org/apache/catalina/session/AbstractHttpSession.java
+++ b/tomcat/src/main/java/org/apache/catalina/session/AbstractHttpSession.java
@@ -6,22 +6,26 @@ import jakarta.servlet.http.HttpSessionContext;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class AbstractHttpSession implements HttpSession {
 
+    private static final long MILLIS_PER_SECOND = 1000L;
+
     protected final String id;
     protected final long creationTime;
-    protected long lastAccessedTime;
+    protected AtomicLong lastAccessedTime;
     protected int maxInactiveInterval;
-    protected boolean isNew = true;
-    protected boolean valid = true;
+    protected final AtomicBoolean isNew = new AtomicBoolean(true);
+    protected final AtomicBoolean valid = new AtomicBoolean(true);
 
     protected final ServletContext servletContext;
 
     protected AbstractHttpSession(ServletContext servletContext) {
         this.id = UUID.randomUUID().toString();
         this.creationTime = System.currentTimeMillis();
-        this.lastAccessedTime = this.creationTime;
+        this.lastAccessedTime = new AtomicLong(this.creationTime);
         this.servletContext = servletContext;
     }
 
@@ -41,15 +45,15 @@ public abstract class AbstractHttpSession implements HttpSession {
      * 마지막 요청 시각 반환
      */
     @Override
-    public long getLastAccessedTime() { checkValid(); return lastAccessedTime; }
+    public long getLastAccessedTime() { checkValid(); return lastAccessedTime.get(); }
 
     /**
      * 세션에 접근(access)했음을 기록하는 메서드.
      * why? 세션 만료 처리 기준이 lastAccessedTime 기반이므로, 요청이 들어올 때마다 이 값을 갱신해야 세션 유지가 가능
      */
     public void access() {
-        this.lastAccessedTime = System.currentTimeMillis();
-        this.isNew = false;
+        lastAccessedTime.set(System.currentTimeMillis());
+        isNew.set(false);
     }
 
     /**
@@ -75,23 +79,27 @@ public abstract class AbstractHttpSession implements HttpSession {
      * 세션 강제로 무효화
      */
     @Override
-    public void invalidate() { valid = false; }
+    public void invalidate() { valid.set(false); }
 
     /**
      * 세션이 새로 생성된 것인지 여부
      */
     @Override
-    public boolean isNew() { checkValid(); return isNew; }
+    public boolean isNew() { checkValid(); return isNew.get(); }
 
     public void checkValid() {
-        if (!valid) {
-            throw new IllegalStateException("Session is invalidated");
+        if (!valid.get() || isExpired()) {
+            throw new IllegalStateException("세션이 이미 만료되었거나 무효화되었습니다.");
         }
     }
 
     public boolean isExpired() {
-        if (maxInactiveInterval <= 0) return false;
-        return (System.currentTimeMillis() - lastAccessedTime) > (maxInactiveInterval * 1000L);
+        if (maxInactiveInterval <= 0) {
+            return false;
+        }
+        long inactiveDuration = System.currentTimeMillis() - lastAccessedTime.get();
+        long maxInactiveMillis = maxInactiveInterval * MILLIS_PER_SECOND;
+        return inactiveDuration > maxInactiveMillis;
     }
 
     @Deprecated

--- a/tomcat/src/main/java/org/apache/catalina/session/HttpSessionImpl.java
+++ b/tomcat/src/main/java/org/apache/catalina/session/HttpSessionImpl.java
@@ -50,4 +50,13 @@ public class HttpSessionImpl extends AbstractHttpSession {
         super.invalidate();
         attributes.clear();
     }
+
+    public boolean isValid() {
+        try {
+            checkValid();
+            return true;
+        } catch (IllegalStateException e) {
+            return false;
+        }
+    }
 }

--- a/tomcat/src/main/java/org/apache/catalina/session/HttpSessionImpl.java
+++ b/tomcat/src/main/java/org/apache/catalina/session/HttpSessionImpl.java
@@ -5,16 +5,19 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class HttpSessionImpl extends AbstractHttpSession {
 
     private final Map<String, Object> attributes = new ConcurrentHashMap<>();
+    private final AtomicBoolean invalidated = new AtomicBoolean(false);
 
     public HttpSessionImpl(ServletContext servletContext) {
         super(servletContext);
     }
 
-    @Override    public Object getAttribute(String name) {
+    @Override
+    public Object getAttribute(String name) {
         checkValid();
         return attributes.get(name);
     }
@@ -42,5 +45,11 @@ public class HttpSessionImpl extends AbstractHttpSession {
     public void removeAttribute(String name) {
         checkValid();
         attributes.remove(name);
+    }
+
+    @Override
+    public void invalidate() {
+        super.invalidate();
+        attributes.clear();
     }
 }

--- a/tomcat/src/main/java/org/apache/catalina/session/HttpSessionImpl.java
+++ b/tomcat/src/main/java/org/apache/catalina/session/HttpSessionImpl.java
@@ -5,12 +5,10 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 public class HttpSessionImpl extends AbstractHttpSession {
 
     private final Map<String, Object> attributes = new ConcurrentHashMap<>();
-    private final AtomicBoolean invalidated = new AtomicBoolean(false);
 
     public HttpSessionImpl(ServletContext servletContext) {
         super(servletContext);

--- a/tomcat/src/main/java/org/apache/catalina/session/SessionManager.java
+++ b/tomcat/src/main/java/org/apache/catalina/session/SessionManager.java
@@ -38,7 +38,7 @@ public class SessionManager implements Manager {
         }
 
         return SESSIONS.computeIfPresent(id, (k, session) -> {
-            if (session.isExpired()) {
+            if (!session.isValid() || session.isExpired()) {
                 session.invalidate();
                 return null;
             }

--- a/tomcat/src/main/java/org/apache/catalina/session/SessionManager.java
+++ b/tomcat/src/main/java/org/apache/catalina/session/SessionManager.java
@@ -33,32 +33,34 @@ public class SessionManager implements Manager {
 
     @Override
     public HttpSession findSession(String id) throws IOException {
-        if (id == null) return null;
-
-        HttpSessionImpl session = SESSIONS.get(id);
-        if (session == null) return null;
-
-        if (session.isExpired()) {
-            remove(session);
+        if (id == null) {
             return null;
         }
 
-        session.access();
-        return session;
+        return SESSIONS.computeIfPresent(id, (k, session) -> {
+            if (session.isExpired()) {
+                session.invalidate();
+                return null;
+            }
+            session.access(); // 접근 시간 갱신
+            return session;
+        });
     }
 
     @Override
     public void add(HttpSession session) {
         if (session instanceof HttpSessionImpl s) {
-            SESSIONS.put(s.getId(), s);
+            SESSIONS.putIfAbsent(s.getId(), s);
         }
     }
 
     @Override
     public void remove(HttpSession session) {
         if (session instanceof HttpSessionImpl s) {
-            s.invalidate();
-            SESSIONS.remove(s.getId());
+            SESSIONS.computeIfPresent(s.getId(), (k, v) -> {
+                v.invalidate();
+                return null; // null → remove
+            });
         }
     }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/http/HttpVersion.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/http/HttpVersion.java
@@ -16,7 +16,7 @@ public enum HttpVersion {
     }
 
     public static HttpVersion from(String value) {
-        Arrays.stream(HttpVersion.values())
+        return Arrays.stream(HttpVersion.values())
                 .filter(v -> v.text.equalsIgnoreCase(value))
                 .findFirst()
                 .orElseThrow(() -> new HttpVersionNotSupported("지원하지 않는 HTTP 버전: " + value));


### PR DESCRIPTION
노랑 안녕하세요 🐥🐥🐥
드디어 마지막이네요 🐥🐥🐥
잘 부탁드립니다. 화이팅!

## 🚀 주요 변화

### 1. Executors로 Thread Pool 적용

기존 방식은 클라이언트 요청이 들어올 때마다 새로운 스레드를 직접 생성하고 실행했습니다.  
이 방식은 무척이나 간단하지만 3가지 단점이 존재했습니다.
1. 요청이 많아질수록 스레드가 무한정 생성 
2. 스레드 생성/해제 비용이 지속 발생
3. 스레드 개수를 제어하기 어려움

이를 해결하기 위해 미션에서 제시한 `Thread Pool`을 도입했습니다. 



최대 스레드 개수는 정하기 어려웠습니다.
실제로 CPU 바운드 작업이라면 코어 수 + α 정도로 스레드를 제한하는 것이 맞지만,
I/O 바운드 작업에서는 CPU가 놀고 있는 시간이 많아 더 많은 스레드를 동시에 두어도 효율적이라고 합니다.
이런 이유로 실무에서 많이 쓰이는 서버들도 기본값을 크게 잡는다고 합니다.
Tomcat -> 200
Jetty -> 200
Undertow -> 200 

저 역시 정확한 최적값을 미리 계산하기 보다는 이미 사용되고 표준에 가까은 200을 우선 설정했습니다. 

---

### 2. 동시성 컬렉션 사용하기

동시성 컬렉션을 적용하여 멀티스레드 환경에서도 안전하게 세션 생성, 조회, 삭제가 가능하도록 개선했습니다.

<br>

---
---

## 🤔 LMS 생각해보기 

>📌 acceptCount와 maxThreads는 각각 어떤 설정일까?
- acceptCount
  - 모든 스레드가 바쁠 때, 추가 요청을 대기열에 쌓을 수 있는 최대 개수 
    - 클라이언트가 서버에 연결 요청을 보냈을 때, 이미 모든 요청 처리 스레드가 바쁘다면 추가 요청을 대기열(queue)에 넣을 수 있다. 이때 대기열의 최대 크기를 지정하는 값이 `acceptCount`

ex) acceptCount = 100 -> 최대 100개까지 요청이 줄 설있을 수 있음   

- maxThreads
  -  **동시에 요청을 처리할 수 있는 스레드 풀의 최대 크기**
  - 요청이 들어오면 스레드 풀에서 스레드를 빌려와 처리하고 끝나면 반환한다. 

>📌 최대 ThradPool의 크기는 250, 모든 Thread가 사용 중인(Busy) 상태이면 100명까지 대기 상태로 만들려면 어떻게 할까?

- maxThreads = 250
- acceptCount = 100

-> 동시에 처리할 수 있는 요청 250개, 이미 250개가 실행 중이라면 추가 100개는 대기열에 저장, 351번째 요청부터는 거절됨

