### PR TITLE
[4단계 - 동시성 확장하기] 피글렛(김은수) 미션 제출합니다.

### DIFF
--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -1,13 +1,14 @@
 package org.apache.catalina.connector;
 
-import org.apache.coyote.http11.Http11Processor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.coyote.http11.Http11Processor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Connector implements Runnable {
 
@@ -15,16 +16,19 @@ public class Connector implements Runnable {
 
     private static final int DEFAULT_PORT = 8080;
     private static final int DEFAULT_ACCEPT_COUNT = 100;
+    private static final int DEFAULT_MAX_THREAD_COUNT = 200;
 
     private final ServerSocket serverSocket;
+    private final ExecutorService executorService;
     private boolean stopped;
 
     public Connector() {
-        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT);
+        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT, DEFAULT_MAX_THREAD_COUNT);
     }
 
-    public Connector(final int port, final int acceptCount) {
+    public Connector(final int port, final int acceptCount, final int maxThreads) {
         this.serverSocket = createServerSocket(port, acceptCount);
+        this.executorService = Executors.newFixedThreadPool(maxThreads);
         this.stopped = false;
     }
 
@@ -67,7 +71,7 @@ public class Connector implements Runnable {
             return;
         }
         var processor = new Http11Processor(connection);
-        new Thread(processor).start();
+        executorService.submit(processor);
     }
 
     public void stop() {

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -71,7 +71,7 @@ public class Connector implements Runnable {
             return;
         }
         var processor = new Http11Processor(connection);
-        executorService.submit(processor);
+        executorService.execute(processor);
     }
 
     public void stop() {

--- a/tomcat/src/main/java/org/apache/catalina/session/Session.java
+++ b/tomcat/src/main/java/org/apache/catalina/session/Session.java
@@ -1,13 +1,13 @@
 package org.apache.catalina.session;
 
 import com.techcourse.model.User;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class Session {
 
     private final String id;
-    private final Map<String, Object> values = new HashMap<>();
+    private final Map<String, Object> values = new ConcurrentHashMap<>();
 
     public Session(final String id) {
         this.id = id;

--- a/tomcat/src/main/java/org/apache/catalina/session/SessionManager.java
+++ b/tomcat/src/main/java/org/apache/catalina/session/SessionManager.java
@@ -1,12 +1,12 @@
 package org.apache.catalina.session;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.catalina.Manager;
 
 public class SessionManager implements Manager {
 
-    private static final Map<String, Session> SESSIONS = new HashMap<>();
+    private static final Map<String, Session> SESSIONS = new ConcurrentHashMap<>();
     private static final SessionManager INSTANCE = new SessionManager();
 
     public static SessionManager getInstance() {


### PR DESCRIPTION
안녕하세요 두리!

이번 미션은 학습 위주라 코드 변경사항이 많이 없습니다..!

- `FixedThreadPool()`로 스레드풀을 생성했습니다!
- `DEFAULT_MAX_THREAD_COUNT`는 계산할 수 있는 공식이 따로 있었는데, 현재 상황에서는 CPU 개수나 스레드 유휴 시간 등 알기 어려운 정보들로 계산해야 하더라구요..! 그래서 일단 spring의 tomcat 기본 스레드풀 max 수를 따라가게 되었습니다.
- `SessionManager`에서 session map 접근의 동시성 고려를 위해 `ConcurrentHashMap`으로 수정했습니다. 
- `Session`에 있는 attribute의 map도 동일하게 적용했습니다.

---
개인적으로는 `Session`의 attribute는 동시에 읽고 쓰는 일이 잦을까 싶어서 동시성 컬렉션 적용이 적절할지 고민되었습니다..!
attribute에 대해 race condition이 발생할 경우를 고려해봤을 때, 한 명의 사용자가 여러 탭에서 동시에 로그인 / 로그아웃을 하게 되면 user attribute가 의도치 않게 로그아웃 했음에도 남아있을 수 있지 않을까 싶었습니다.

정말 일어날 수 있는 경우에 대한 동시성 고려였을지 아직 판단이 잘 안서기도 하네요 ㅎㅎ 😅