### PR TITLE
[4단계 - 동시성 확장하기] 제프리(홍성호) 미션 제출합니다.

### DIFF
--- a/study/src/test/java/thread/stage0/SynchronizationTest.java
+++ b/study/src/test/java/thread/stage0/SynchronizationTest.java
@@ -41,7 +41,7 @@ class SynchronizationTest {
 
         private int sum = 0;
 
-        public void calculate() {
+        public synchronized void calculate() {
             setSum(getSum() + 1);
         }
 

--- a/study/src/test/java/thread/stage0/ThreadPoolsTest.java
+++ b/study/src/test/java/thread/stage0/ThreadPoolsTest.java
@@ -31,8 +31,8 @@ class ThreadPoolsTest {
         executor.submit(logWithSleep("hello fixed thread pools"));
 
         // 올바른 값으로 바꿔서 테스트를 통과시키자.
-        final int expectedPoolSize = 0;
-        final int expectedQueueSize = 0;
+        final int expectedPoolSize = 2;
+        final int expectedQueueSize = 1;
 
         assertThat(expectedPoolSize).isEqualTo(executor.getPoolSize());
         assertThat(expectedQueueSize).isEqualTo(executor.getQueue().size());
@@ -46,7 +46,7 @@ class ThreadPoolsTest {
         executor.submit(logWithSleep("hello cached thread pools"));
 
         // 올바른 값으로 바꿔서 테스트를 통과시키자.
-        final int expectedPoolSize = 0;
+        final int expectedPoolSize = 3;
         final int expectedQueueSize = 0;
 
         assertThat(expectedPoolSize).isEqualTo(executor.getPoolSize());

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -43,6 +43,13 @@ public class Connector implements Runnable {
         }
     }
 
+    public void start() {
+        var thread = new Thread(this);
+        thread.setDaemon(true);
+        thread.start();
+        stopped = false;
+    }
+
     @Override
     public void run() {
         log.info("Web Application Server started {} port.", serverSocket.getLocalPort());

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -1,13 +1,15 @@
 package org.apache.catalina.connector;
 
-import org.apache.coyote.http11.Http11Processor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.apache.coyote.http11.Http11Processor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Connector implements Runnable {
 
@@ -15,16 +17,19 @@ public class Connector implements Runnable {
 
     private static final int DEFAULT_PORT = 8080;
     private static final int DEFAULT_ACCEPT_COUNT = 100;
+    private static final int DEFAULT_MAX_THREADS = 250;
 
     private final ServerSocket serverSocket;
+    private final ExecutorService executor;
     private boolean stopped;
 
     public Connector() {
-        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT);
+        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT, DEFAULT_MAX_THREADS);
     }
 
-    public Connector(final int port, final int acceptCount) {
+    public Connector(final int port, final int acceptCount, final int maxThreads) {
         this.serverSocket = createServerSocket(port, acceptCount);
+        this.executor = Executors.newFixedThreadPool(maxThreads);
         this.stopped = false;
     }
 
@@ -38,17 +43,9 @@ public class Connector implements Runnable {
         }
     }
 
-    public void start() {
-        var thread = new Thread(this);
-        thread.setDaemon(true);
-        thread.start();
-        stopped = false;
-        log.info("Web Application Server started {} port.", serverSocket.getLocalPort());
-    }
-
     @Override
     public void run() {
-        // 클라이언트가 연결될때까지 대기한다.
+        log.info("Web Application Server started {} port.", serverSocket.getLocalPort());
         while (!stopped) {
             connect();
         }
@@ -67,13 +64,15 @@ public class Connector implements Runnable {
             return;
         }
         var processor = new Http11Processor(connection);
-        new Thread(processor).start();
+        executor.execute(processor);
+        logExecutorStats(executor);
     }
 
     public void stop() {
         stopped = true;
         try {
             serverSocket.close();
+            executor.close();
         } catch (IOException e) {
             log.error(e.getMessage(), e);
         }
@@ -91,5 +90,36 @@ public class Connector implements Runnable {
 
     private int checkAcceptCount(final int acceptCount) {
         return Math.max(acceptCount, DEFAULT_ACCEPT_COUNT);
+    }
+
+    private void logExecutorStats(ExecutorService executor) {
+        if (executor instanceof ThreadPoolExecutor tpe) {
+            var queue = tpe.getQueue();
+            log.info("""
+            
+            ----------Pool stats---------- 
+              poolSize={}
+              corePoolSize={}
+              maxPoolSize={}
+              largestPoolSize={} 
+              activeCount={}
+              completedTaskCount={}
+              taskCount={} 
+              queueSize={}
+              queueRemainingCapacity={}
+            """,
+                    tpe.getPoolSize(),           // poolSize: 현재 풀 내 총 스레드 수(유휴+활성)
+                    tpe.getCorePoolSize(),       // corePoolSize: 코어 스레드 수
+                    tpe.getMaximumPoolSize(),    // maxPoolSize: 최대 스레드 수
+                    tpe.getLargestPoolSize(),    // largestPoolSize: 역사상 최대로 늘어난 스레드 수
+                    tpe.getActiveCount(),        // activeCount: 현재 실행 중인 스레드 수
+                    tpe.getCompletedTaskCount(), // completedTaskCount: 완료된 전체 작업 수
+                    tpe.getTaskCount(),          // taskCount: 제출된 전체 작업 수(완료+대기+실행 포함)
+                    queue.size(),                // queueSize: 큐에 대기 중인 작업 수
+                    queue.remainingCapacity()    // queueRemainingCapacity큐의 남은 수용량
+            );
+        } else {
+            log.warn("Executor is not a ThreadPoolExecutor, cannot inspect internals.");
+        }
     }
 }

--- a/tomcat/src/main/java/org/apache/catalina/startup/Tomcat.java
+++ b/tomcat/src/main/java/org/apache/catalina/startup/Tomcat.java
@@ -12,7 +12,7 @@ public class Tomcat {
 
     public void start() {
         var connector = new Connector();
-        connector.run();
+        connector.start();
 
         try {
             // make the application wait until we press any key.

--- a/tomcat/src/main/java/org/apache/catalina/startup/Tomcat.java
+++ b/tomcat/src/main/java/org/apache/catalina/startup/Tomcat.java
@@ -12,7 +12,7 @@ public class Tomcat {
 
     public void start() {
         var connector = new Connector();
-        connector.start();
+        connector.run();
 
         try {
             // make the application wait until we press any key.


### PR DESCRIPTION
안녕하세요 코기 🙋 벌써 마지막 미션이네요. 잘부탁드려요 😄 

- Executors로 Thread Pool 적용
    - Executors.newFixedThreadPool(maxThreads); 로 쓰레드 풀 생성
 - 동시성 컬렉션 사용하기
    - 이미 `ConcurrentHashMap` 을 사용하고 있어서, 별도로 수정하지 않았습니다. 

실행해보시면, 쓰레드 풀이 

> queueRemainingCapacity=2147483647 

로 로그가 찍히는 것을 확인하실 수 있습니다. 

이는 Executors.newFixedThreadPool의 기본 workQueue는 용량을 지정하지 않은 LinkedBlockingQueue이며, 이 경우 내부 용량이 Integer.MAX_VALUE로 설정되어 있는 무제한 큐 라고 합니다. 따라서, 큐의 남은 수용량이 Integer.MAX_VALUE로 찍히는게 정상 동작이라고 합니다. 

큐를 명시하기 위해서, 
```java
new ThreadPoolExecutor(
        core,
        max,
        keepAlive,
        unit,
        new ArrayBlockingQueue<>(1000), 
        new ThreadPoolExecutor.CallerRunsPolicy()
);
```
해당 코드로 생성하면 큐를 명시할 수 있다고는 하나, 따로 적용하지는 않았습니다.


로그 예시입니다.
```
----------Pool stats----------
  poolSize=57
  corePoolSize=250
  maxPoolSize=250
  largestPoolSize=57
  activeCount=1
  completedTaskCount=56
  taskCount=57
  queueSize=0
  queueRemainingCapacity=2147483647
```
