### PR TITLE
[4단계 - 동시성 확장하기] 줄리(한승아) 미션 제출합니다.

### DIFF
--- a/tomcat/src/main/java/com/techcourse/Service.java
+++ b/tomcat/src/main/java/com/techcourse/Service.java
@@ -4,6 +4,7 @@ import com.techcourse.db.InMemoryUserRepository;
 import com.techcourse.model.User;
 import java.time.LocalDateTime;
 import java.util.Map;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,7 +29,14 @@ public class Service {
     }
 
     public User registerUser(final String account, final String password, final String email) {
+        Optional<User> user = InMemoryUserRepository.findByAccount(account);
+        if (user.isPresent()) {
+            throw new IllegalArgumentException("이미 가입한 사용자입니다.");
+        }
         InMemoryUserRepository.save(new User(account, password, email));
+
+        log.info("Registered account [{}]", account);
+
         return findUserByAccount(account);
     }
 }

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -1,13 +1,14 @@
 package org.apache.catalina.connector;
 
-import org.apache.coyote.http11.Http11Processor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.coyote.http11.Http11Processor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Connector implements Runnable {
 
@@ -15,15 +16,18 @@ public class Connector implements Runnable {
 
     private static final int DEFAULT_PORT = 8080;
     private static final int DEFAULT_ACCEPT_COUNT = 100;
+    private static final int DEFAULT_MAX_THREADS_COUNT = 200;
 
+    private final ExecutorService executorService;
     private final ServerSocket serverSocket;
     private boolean stopped;
 
     public Connector() {
-        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT);
+        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT, DEFAULT_MAX_THREADS_COUNT);
     }
 
-    public Connector(final int port, final int acceptCount) {
+    public Connector(final int port, final int acceptCount, final int maxThreads) {
+        this.executorService = Executors.newFixedThreadPool(maxThreads);
         this.serverSocket = createServerSocket(port, acceptCount);
         this.stopped = false;
     }
@@ -57,17 +61,17 @@ public class Connector implements Runnable {
     private void connect() {
         try {
             process(serverSocket.accept());
-        } catch (IOException e) {
+        } catch (IOException | InterruptedException e) {
             log.error(e.getMessage(), e);
         }
     }
 
-    private void process(final Socket connection) {
+    private void process(final Socket connection) throws InterruptedException {
         if (connection == null) {
             return;
         }
         var processor = new Http11Processor(connection);
-        new Thread(processor).start();
+        executorService.execute(processor);
     }
 
     public void stop() {

--- a/tomcat/src/main/java/org/apache/coyote/RequestMapping.java
+++ b/tomcat/src/main/java/org/apache/coyote/RequestMapping.java
@@ -8,13 +8,17 @@ import org.apache.coyote.controller.RootController;
 
 public class RequestMapping {
 
+    private static final RootController rootController = new RootController();
+    private static final LoginController loginController = new LoginController();
+    private static final RegisterController registerController = new RegisterController();
+
     public Controller getController(final HttpRequest request) {
         if (request.getPath().startsWith("/login")) {
-            return new LoginController();
+            return loginController;
         }
         if (request.getPath().startsWith("/register")) {
-            return new RegisterController();
+            return registerController;
         }
-        return new RootController();
+        return rootController;
     }
 }

--- a/tomcat/src/main/java/org/apache/coyote/common/HttpResponse.java
+++ b/tomcat/src/main/java/org/apache/coyote/common/HttpResponse.java
@@ -29,12 +29,13 @@ public class HttpResponse {
     private String getMessage() {
         StringBuilder builder = new StringBuilder();
 
-        builder.append(protocol).append(" ").append(status.getCode()).append(" ").append(status.getMessage()).append(" \r\n");
+        builder.append(protocol).append(" ").append(status.getCode()).append(" ").append(status.getMessage()).append("\r\n");
 
         if (headers != null) {
-            headers.forEach((key, value) -> builder.append(key).append(": ").append(value).append(" \r\n"));
+            headers.forEach((key, value) -> builder.append(key).append(": ").append(value).append("\r\n"));
         }
         if (body == null) {
+            builder.append("\r\n");
             return builder.toString();
         }
 

--- a/tomcat/src/main/java/org/apache/coyote/controller/LoginController.java
+++ b/tomcat/src/main/java/org/apache/coyote/controller/LoginController.java
@@ -2,6 +2,7 @@ package org.apache.coyote.controller;
 
 import com.techcourse.Service;
 import com.techcourse.model.User;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -59,7 +60,7 @@ public class LoginController extends AbstractController {
     }
 
     @Override
-    protected void doPost(final HttpRequest request, final HttpResponse response) {
+    protected void doPost(final HttpRequest request, final HttpResponse response) throws IOException {
         response.setProtocol(request.getProtocol());
         if (request.getBody() == null) {
             response.setStatus(HttpStatus.BAD_REQUEST);
@@ -75,9 +76,15 @@ public class LoginController extends AbstractController {
             body.put(key, value);
         }
 
+        Session session = getCookieSession(request);
+        if (session != null) {
+            response.setStatus(HttpStatus.BAD_REQUEST);
+            return;
+        }
+
         try {
             User user = service.getLoggedInUser(body);
-            UUID uuid = createSession(user);
+            UUID uuid = createUserSession(user);
 
             final Map<String, String> headers = new HashMap<>();
             headers.put("Set-Cookie", "JSESSIONID=" + uuid);
@@ -95,26 +102,12 @@ public class LoginController extends AbstractController {
     }
 
     private void handleRedirect(final HttpRequest request, final HttpResponse response) throws Exception {
-        HttpCookie cookie = request.getCookie();
-
-        if (cookie == null) {
-            doGet(request, response);
-            return;
-        }
-
-        String sessionId = cookie.getValue("JSESSIONID");
-
-        if (sessionId == null) {
-            doGet(request, response);
-            return;
-        }
-
-        Manager sessionManager = SessionManager.getInstance();
-        Session session = sessionManager.findSession(sessionId);
+        Session session = getCookieSession(request);
         if (session == null) {
             doGet(request, response);
             return;
         }
+
         Map<String, String> headers = new HashMap<>();
         headers.put("Location", "/index.html");
         response.setHeaders(headers);
@@ -122,7 +115,22 @@ public class LoginController extends AbstractController {
         response.setProtocol(request.getProtocol());
     }
 
-    private UUID createSession(final User user) {
+    private Session getCookieSession(final HttpRequest request) throws IOException {
+        HttpCookie cookie = request.getCookie();
+        if (cookie == null) {
+            return null;
+        }
+
+        String sessionId = cookie.getValue("JSESSIONID");
+        if (sessionId == null) {
+            return null;
+        }
+
+        Manager sessionManager = SessionManager.getInstance();
+        return sessionManager.findSession(sessionId);
+    }
+
+    private UUID createUserSession(final User user) {
         UUID uuid = UUID.randomUUID();
         SessionManager sessionManager = SessionManager.getInstance();
         Session loginSession = new Session(uuid.toString());

--- a/tomcat/src/main/java/org/apache/coyote/controller/RegisterController.java
+++ b/tomcat/src/main/java/org/apache/coyote/controller/RegisterController.java
@@ -2,6 +2,7 @@ package org.apache.coyote.controller;
 
 import com.techcourse.Service;
 import com.techcourse.model.User;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -76,7 +77,7 @@ public class RegisterController extends AbstractController {
         }
 
         User user = service.registerUser(body.get("account"), body.get("password"), body.get("email"));
-        UUID uuid = createSession(user);
+        UUID uuid = createUserSession(user);
 
         Map<String, String> headers = new HashMap<>();
         headers.put("Set-Cookie", "JSESSIONID=" + uuid);
@@ -86,23 +87,23 @@ public class RegisterController extends AbstractController {
         response.setHeaders(headers);
     }
 
-    private void handleRedirect(final HttpRequest request, final HttpResponse response) throws Exception {
+    private Session getCookieSession(final HttpRequest request) throws IOException {
         HttpCookie cookie = request.getCookie();
-
         if (cookie == null) {
-            doGet(request, response);
-            return;
+            return null;
         }
 
         String sessionId = cookie.getValue("JSESSIONID");
-
         if (sessionId == null) {
-            doGet(request, response);
-            return;
+            return null;
         }
 
         Manager sessionManager = SessionManager.getInstance();
-        Session session = sessionManager.findSession(sessionId);
+        return sessionManager.findSession(sessionId);
+    }
+
+    private void handleRedirect(final HttpRequest request, final HttpResponse response) throws Exception {
+        Session session = getCookieSession(request);
         if (session == null) {
             doGet(request, response);
             return;
@@ -115,7 +116,7 @@ public class RegisterController extends AbstractController {
         response.setProtocol(request.getProtocol());
     }
 
-    private UUID createSession(final User user) {
+    private UUID createUserSession(final User user) {
         UUID uuid = UUID.randomUUID();
         SessionManager sessionManager = SessionManager.getInstance();
         Session loginSession = new Session(uuid.toString());

--- a/tomcat/src/main/java/org/apache/coyote/controller/RegisterController.java
+++ b/tomcat/src/main/java/org/apache/coyote/controller/RegisterController.java
@@ -76,15 +76,21 @@ public class RegisterController extends AbstractController {
             body.put(key, value);
         }
 
-        User user = service.registerUser(body.get("account"), body.get("password"), body.get("email"));
-        UUID uuid = createUserSession(user);
+        synchronized (this) {
+            try {
+                User user = service.registerUser(body.get("account"), body.get("password"), body.get("email"));
+                UUID uuid = createUserSession(user);
 
-        Map<String, String> headers = new HashMap<>();
-        headers.put("Set-Cookie", "JSESSIONID=" + uuid);
-        headers.put("Location", "/index.html");
+                Map<String, String> headers = new HashMap<>();
+                headers.put("Set-Cookie", "JSESSIONID=" + uuid);
+                headers.put("Location", "/index.html");
 
-        response.setStatus(HttpStatus.FOUND);
-        response.setHeaders(headers);
+                response.setStatus(HttpStatus.FOUND);
+                response.setHeaders(headers);
+            } catch (RuntimeException e) {
+                response.setStatus(HttpStatus.BAD_REQUEST);
+            }
+        }
     }
 
     private Session getCookieSession(final HttpRequest request) throws IOException {

--- a/tomcat/src/test/java/ThreadTest.java
+++ b/tomcat/src/test/java/ThreadTest.java
@@ -1,0 +1,47 @@
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.http.HttpResponse;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import support.TestHttpUtils;
+
+class ThreadTest {
+
+    private static final AtomicInteger httpCallCount = new AtomicInteger(0);
+
+    @Test
+    @DisplayName("여러 스레드가 동시에 회원가입을 진행할 경우 한 스레드만 302 Found 응답을 받는다.")
+    void multiThreadRegistrationTest() throws InterruptedException {
+        // Given
+        String path = "/register";
+        String body = "account=gugu2&password=password&email=hkkang2@woowahan.com";
+        String contentType = "x-www-form-urlencoded";
+
+        // When
+        int NUMBER_OF_THREADS = 10;
+        Thread[] threads = new Thread[NUMBER_OF_THREADS];
+
+        for (int i = 0; i < NUMBER_OF_THREADS; i++) {
+            threads[i] = new Thread(() -> incrementIfFound(TestHttpUtils.sendPost(path, contentType, body)));
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+            Thread.sleep(50);
+        }
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        // Then
+        assertThat(httpCallCount.get()).isEqualTo(1);
+    }
+
+    private static void incrementIfFound(final HttpResponse<Void> response) {
+        if (response.statusCode() == 302) {
+            httpCallCount.incrementAndGet();
+        }
+    }
+}

--- a/tomcat/src/test/java/ThreadTest.java
+++ b/tomcat/src/test/java/ThreadTest.java
@@ -13,6 +13,9 @@ class ThreadTest {
     @Test
     @DisplayName("여러 스레드가 동시에 회원가입을 진행할 경우 한 스레드만 302 Found 응답을 받는다.")
     void multiThreadRegistrationTest() throws InterruptedException {
+        // HTTP 호출 카운터 재시작
+        httpCallCount.set(0);
+
         // Given
         String path = "/register";
         String body = "account=gugu2&password=password&email=hkkang2@woowahan.com";
@@ -37,6 +40,41 @@ class ThreadTest {
 
         // Then
         assertThat(httpCallCount.get()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("1000개의 스레드가 동시에 index 페이지에 접근할 때 200 OK 응답을 1000회 받는다.")
+    void multiThreadPerformanceTest() throws InterruptedException {
+        // HTTP 호출 카운터 재시작
+        httpCallCount.set(0);
+
+        // Given
+        String path = "/";
+
+        // When
+        int NUMBER_OF_THREADS = 1000;
+        Thread[] threads = new Thread[NUMBER_OF_THREADS];
+
+        for (int i = 0; i < NUMBER_OF_THREADS; i++) {
+            threads[i] = new Thread(() -> incrementIfOk(TestHttpUtils.sendGet(path)));
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        // Then
+        assertThat(httpCallCount.get()).isEqualTo(1000);
+    }
+
+    private static void incrementIfOk(final HttpResponse<String> response) {
+        if (response.statusCode() == 200) {
+            httpCallCount.incrementAndGet();
+        }
     }
 
     private static void incrementIfFound(final HttpResponse<Void> response) {

--- a/tomcat/src/test/java/support/TestHttpUtils.java
+++ b/tomcat/src/test/java/support/TestHttpUtils.java
@@ -1,0 +1,31 @@
+package support;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+public class TestHttpUtils {
+
+    private static final HttpClient httpClient = HttpClient.newBuilder()
+            .version(HttpClient.Version.HTTP_1_1)
+            .connectTimeout(Duration.ofSeconds(1))
+            .build();
+
+    public static HttpResponse<Void> sendPost(final String path, final String contentType, final String body) {
+        final var request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:8080" + path))
+                .timeout(Duration.ofSeconds(1))
+                .header("Content-Type", "application/" + contentType)
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+
+        try {
+            return httpClient.send(request, HttpResponse.BodyHandlers.discarding());
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/tomcat/src/test/java/support/TestHttpUtils.java
+++ b/tomcat/src/test/java/support/TestHttpUtils.java
@@ -14,6 +14,19 @@ public class TestHttpUtils {
             .connectTimeout(Duration.ofSeconds(1))
             .build();
 
+    public static HttpResponse<String> sendGet(final String path) {
+        final var request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:8080" + path))
+                .timeout(Duration.ofSeconds(1))
+                .build();
+
+        try {
+            return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public static HttpResponse<Void> sendPost(final String path, final String contentType, final String body) {
         final var request = HttpRequest.newBuilder()
                 .uri(URI.create("http://localhost:8080" + path))


### PR DESCRIPTION
👋 안녕하세요, 레몬!

어느덧 4단계네요! 이번 단계에서는 동시성을 학습하고 스레드풀을 적용하는 부분에 집중해보았습니다.

미션에서 사용하는 `/login`, `/register` 엔드포인트 중, 아래와 같은 이유로 `/register`에만 race condition을 방지하기 위한 조치를 취했습니다:
- 회원가입은 한번에 한 unique한 계정에 대해서만 허용해야 함 (동일한 account/email 정보로 사용자 계정이 중복으로 생성되는 것을 방지)
- 로그인은 사용자가 동시에 여러 기기나 환경에서 시도할 수 있어서, 단순히 한 User 데이터에 대한 세션만 저장하도록 강제하기에는 사용성이 떨어진다고 판단됨. 따라서 한 User에 대해 다수의 세션을 저장할 수 있도록 허용하되, `/login`을 호출했을 때 이미 요청 쿠키의 세션 id로 로그인 기록이 존재하는 경우에는 400을 응답하도록 구현

3단계 때 언급해주셨던 AbstractController는 추상적인 클래스인데 Login과 Register 같은 일부 컨트롤러만 필요한 기능을 구현하면 추상성을 잃게 되어서, 이번 단계에서는 따로 리팩터링을 하지 않았습니다. 아직은 뚜렷한 개선점을 찾지 못했지만, MVC 미션을 통해 좋은 솔루션을 찾아내길 기대하고 있습니다! 😀

마지막 리뷰도 잘 부탁드립니다! 🙏