### PR TITLE
[4단계 - 동시성 확장하기] 우가(민보욱) 미션 제출합니다.

### DIFF
--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -24,6 +24,8 @@ public class Connector implements Runnable {
     //이게 내 컴퓨터 상태니까, 이론상 8코어 사용 가능한거네 하이퍼 스레딩 덕분에
     //db가 없고 다 인메모리니까, disk i/o는 없을 것 같은데 그러면 wait time을 0이라고 했을 때
     //8 곱하기 (1 + 0)이니까 그러면 8이네
+    //근데, .css, .html 같은 정적 파일이 있네, 그러면 disk i/o가 발생하겠네
+    //그러면 반,반주고 8 곱하기 (1 + 1) 하면 16
     //Optimal Threads = Number of Cores * (1 + Wait time / Service time)
     private static final int DEFAULT_CORE_POOL_SIZE = 8;
     private static final int DEFAULT_MAX_THREADS = 16;

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -5,7 +5,6 @@ import java.io.UncheckedIOException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.apache.catalina.FrontController;
@@ -19,21 +18,11 @@ public class Connector implements Runnable {
 
     private static final int DEFAULT_PORT = 8080;
     private static final int DEFAULT_ACCEPT_COUNT = 100;
-    //NumberOfCores  NumberOfLogicalProcessors
-    //4              8
-    //이게 내 컴퓨터 상태니까, 이론상 8코어 사용 가능한거네 하이퍼 스레딩 덕분에
-    //db가 없고 다 인메모리니까, disk i/o는 없을 것 같은데 그러면 wait time을 0이라고 했을 때
-    //8 곱하기 (1 + 0)이니까 그러면 8이네
-    //근데, .css, .html 같은 정적 파일이 있네, 그러면 disk i/o가 발생하겠네
-    //그러면 반,반주고 8 곱하기 (1 + 1) 하면 16
-    //Optimal Threads = Number of Cores * (1 + Wait time / Service time)
+    private static final long KEEP_ALIVE = 30L;
     private static final int DEFAULT_CORE_POOL_SIZE = 8;
     private static final int DEFAULT_MAX_THREADS = 16;
 
-    //ExecutorService로 스레드 풀을 통해 작업을 실행할 수 있도록 도와주는 인터페이스임
-    //매번, thread.start()하는 대신, executor.submit(Runnable) 또는 .execute(Runnable)호출
-    //그러면, 미리 준비된 스레드가 작업을 처리함
-    private final ExecutorService threadPool;
+    private final ThreadPoolExecutor threadPool;
     private final ServerSocket serverSocket;
     private volatile boolean stopped;
 
@@ -41,29 +30,22 @@ public class Connector implements Runnable {
         this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT, DEFAULT_CORE_POOL_SIZE, DEFAULT_MAX_THREADS);
     }
 
-    //예를 들어서, 현재 실행 중인 스레드 수 < corePoolSize면 새 스레드를 생성하는 것임.
-    //큐가 비어있지 않으면 -> 큐에 작업 추가 (근데 이 조건이, coreThread가 다 일을 하고 있어야함)
-    //큐가 꽉 찼는데, 현재 스레드 수 < maximumPoolSize -> 새 스레드 생성(이게 초과쓰레드)
-    //위 조건 다 안 되면 즉시 거절
     public Connector(final int port, final int acceptCount, final int corePoolSize, final int maxThreads) {
         this.serverSocket = createServerSocket(port, acceptCount);
         this.stopped = false;
         this.threadPool = new ThreadPoolExecutor(
-                corePoolSize, //풀에서 항상 유지하려는 최소 스레드 수
-                maxThreads, //풀에서 동시에 존재ㅐ할 수 있는 최대 스레드 수
-                30L, //여기서는 그러면 101번부터 200번이 초과된 스레드네
+                corePoolSize,
+                maxThreads,
+                KEEP_ALIVE,
                 TimeUnit.SECONDS,
-                new ArrayBlockingQueue<>(acceptCount) //대기 큐인데, acceptCount만큼 요청을 버퍼링
+                new ArrayBlockingQueue<>(acceptCount)
         );
+
+        this.threadPool.setRejectedExecutionHandler((r, executor) -> {
+            log.error("큐가 곽차서 더이상 작업을 받을 수 없습니다. 작업 클래스={}", r.getClass().getName());
+        });
     }
 
-    //그러면, corePoolSize만큼 스레드가 항상 대기 중이고, 그 스레드 100개가 다 작업을 하고 있지 않는 이상 큐에 작업이 쌓이지는 않겠군
-    //큐가 꽉차면 부하가 장난아닌거네 ㄷㄷ
-    //그러면, 큐가 꽉차면 그때부터 스레드 생성을 시작하니까 101번부터
-    //그러면, 초과된 스레드는 바로 큐에서 작업을 할당 받겠네
-    //그러다가 작업이 할당되지 않은 초과된 스레드는 30초뒤 증발
-    //근데, 만약에 30s를 지정하지 않으면 초과된 스레드는 밀린 작업을 처리했음
-    //근데, 삭제되지 않고 남아있는 것임 그러면 메모리를 계속 차지하는 거임 레전드
     private ServerSocket createServerSocket(final int port, final int acceptCount) {
         try {
             final int checkedPort = checkPort(port);

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -4,6 +4,10 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import org.apache.catalina.FrontController;
 import org.apache.coyote.http11.processor.Http11Processor;
 import org.slf4j.Logger;
@@ -15,19 +19,43 @@ public class Connector implements Runnable {
 
     private static final int DEFAULT_PORT = 8080;
     private static final int DEFAULT_ACCEPT_COUNT = 100;
+    private static final int DEFAULT_CORE_POOL_SIZE = 100;
+    private static final int DEFAULT_MAX_THREADS = 200;
 
+    //ExecutorService로 스레드 풀을 통해 작업을 실행할 수 있도록 도와주는 인터페이스임
+    //매번, thread.start()하는 대신, executor.submit(Runnable) 또는 .execute(Runnable)호출
+    //그러면, 미리 준비된 스레드가 작업을 처리함
+    private final ExecutorService threadPool;
     private final ServerSocket serverSocket;
-    private boolean stopped;
+    private volatile boolean stopped;
 
     public Connector() {
-        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT);
+        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT, DEFAULT_CORE_POOL_SIZE, DEFAULT_MAX_THREADS);
     }
 
-    public Connector(final int port, final int acceptCount) {
+    //예를 들어서, 현재 실행 중인 스레드 수 < corePoolSize면 새 스레드를 생성하는 것임.
+    //큐가 비어있지 않으면 -> 큐에 작업 추가 (근데 이 조건이, coreThread가 다 일을 하고 있어야함)
+    //큐가 꽉 찼는데, 현재 스레드 수 < maximumPoolSize -> 새 스레드 생성(이게 초과쓰레드)
+    //위 조건 다 안 되면 즉시 거절
+    public Connector(final int port, final int acceptCount, final int corePoolSize, final int maxThreads) {
         this.serverSocket = createServerSocket(port, acceptCount);
         this.stopped = false;
+        this.threadPool = new ThreadPoolExecutor(
+                corePoolSize, //풀에서 항상 유지하려는 최소 스레드 수
+                maxThreads, //풀에서 동시에 존재ㅐ할 수 있는 최대 스레드 수
+                30L, //여기서는 그러면 101번부터 200번이 초과된 스레드네
+                TimeUnit.SECONDS,
+                new ArrayBlockingQueue<>(acceptCount) //대기 큐인데, acceptCount만큼 요청을 버퍼링
+        );
     }
 
+    //그러면, corePoolSize만큼 스레드가 항상 대기 중이고, 그 스레드 100개가 다 작업을 하고 있지 않는 이상 큐에 작업이 쌓이지는 않겠군
+    //큐가 꽉차면 부하가 장난아닌거네 ㄷㄷ
+    //그러면, 큐가 꽉차면 그때부터 스레드 생성을 시작하니까 101번부터
+    //그러면, 초과된 스레드는 바로 큐에서 작업을 할당 받겠네
+    //그러다가 작업이 할당되지 않은 초과된 스레드는 30초뒤 증발
+    //근데, 만약에 30s를 지정하지 않으면 초과된 스레드는 밀린 작업을 처리했음
+    //근데, 삭제되지 않고 남아있는 것임 그러면 메모리를 계속 차지하는 거임 레전드
     private ServerSocket createServerSocket(final int port, final int acceptCount) {
         try {
             final int checkedPort = checkPort(port);
@@ -67,13 +95,12 @@ public class Connector implements Runnable {
         if (connection == null) {
             return;
         }
-
-        var processor = new Http11Processor(connection, frontController);
-        new Thread(processor).start();
+        threadPool.submit(new Http11Processor(connection, frontController));
     }
 
     public void stop() {
         stopped = true;
+        threadPool.shutdown(); //그러면, 새로운 작업은 막고, 이미 진행중인 작업은 실행
         try {
             serverSocket.close();
         } catch (IOException e) {

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -19,8 +19,14 @@ public class Connector implements Runnable {
 
     private static final int DEFAULT_PORT = 8080;
     private static final int DEFAULT_ACCEPT_COUNT = 100;
-    private static final int DEFAULT_CORE_POOL_SIZE = 100;
-    private static final int DEFAULT_MAX_THREADS = 200;
+    //NumberOfCores  NumberOfLogicalProcessors
+    //4              8
+    //이게 내 컴퓨터 상태니까, 이론상 8코어 사용 가능한거네 하이퍼 스레딩 덕분에
+    //db가 없고 다 인메모리니까, disk i/o는 없을 것 같은데 그러면 wait time을 0이라고 했을 때
+    //8 곱하기 (1 + 0)이니까 그러면 8이네
+    //Optimal Threads = Number of Cores * (1 + Wait time / Service time)
+    private static final int DEFAULT_CORE_POOL_SIZE = 8;
+    private static final int DEFAULT_MAX_THREADS = 16;
 
     //ExecutorService로 스레드 풀을 통해 작업을 실행할 수 있도록 도와주는 인터페이스임
     //매번, thread.start()하는 대신, executor.submit(Runnable) 또는 .execute(Runnable)호출


### PR DESCRIPTION
안녕하세요! 차니!

마지막 단계에 왔네요.

이번에는 제 개인 컴퓨터 사양을 기준으로 스레드 풀 설정을 해봤습니다.
현재 서비스에서는 디스크 I/O가 아예 없는 것은 아니지만, 많지 않은 상황입니다.
그래서 MAXIMUM_POOL_SIZE를 크게 높일 이유가 딱히 없다고 판단했습니다.

과도한 스레드 수는 오히려 컨텍스트 스위칭 오버헤드만 늘릴 수 있다고 생각했습니다.
실제 CPU 코어와 논리 프로세서 수에 맞춰 적절한 수(예: 16)로 제한하는 것이 낫다고 봤습니다.

근데, 또 생각해보면 톰캣이 웹에서의 순간적인 요청을 다 받아내려면 MAXIMUM_POOL_SIZE가 높아야 할 것 같다고 생각이 들기도 합니다!
이 점 참고 부탁드립니다. 감사합니다!