### PR TITLE
[4단계 - 동시성 확장하기] 노랑 미션 제출합니다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,6 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Compiled source directories
+**/bin/

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -24,7 +24,7 @@ public class Connector implements Runnable {
 
     private final ServerSocket serverSocket;
     private final ExecutorService executor;
-    private boolean stopped;
+    private volatile boolean stopped;
 
     public Connector() {
         this(
@@ -84,7 +84,11 @@ public class Connector implements Runnable {
         try {
             process(serverSocket.accept());
         } catch (IOException e) {
-            log.error(e.getMessage(), e);
+            if (stopped || serverSocket.isClosed()) {
+                log.info("서버가 정상적으로 종료되었습니다.");
+                return;
+            }
+            log.error("클라이언트 연결 처리 중 오류: {}", e.getMessage());
         }
     }
 
@@ -101,7 +105,7 @@ public class Connector implements Runnable {
         try {
             serverSocket.close();
         } catch (IOException e) {
-            log.error(e.getMessage(), e);
+            log.error("서버 소켓 종료 중 오류: {}", e.getMessage());
         }
     }
 

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -5,7 +5,9 @@ import java.io.UncheckedIOException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import org.apache.coyote.http11.Http11Processor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,20 +18,40 @@ public class Connector implements Runnable {
 
     private static final int DEFAULT_PORT = 8080;
     private static final int DEFAULT_ACCEPT_COUNT = 100;
-    private static final int DEFAULT_MAX_THREAD = 100;
+    private static final int DEFAULT_MIN_SPARE_THREADS = 10;
+    private static final int DEFAULT_MAX_THREADS = 200;
+    private static final int DEFAULT_THREADS_MAX_IDLE_TIME = 60;
 
     private final ServerSocket serverSocket;
     private final ExecutorService executor;
     private boolean stopped;
 
     public Connector() {
-        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT, DEFAULT_MAX_THREAD);
+        this(
+                DEFAULT_PORT,
+                DEFAULT_ACCEPT_COUNT,
+                DEFAULT_MIN_SPARE_THREADS,
+                DEFAULT_MAX_THREADS,
+                DEFAULT_THREADS_MAX_IDLE_TIME
+        );
     }
 
-    public Connector(final int port, final int acceptCount, final int maxThreads) {
+    public Connector(
+            final int port,
+            final int acceptCount,
+            final int minSpareThreads,
+            final int maxThreads,
+            final int threadsMaxIdleTime
+    ) {
         this.serverSocket = createServerSocket(port, acceptCount);
         this.stopped = false;
-        this.executor = Executors.newFixedThreadPool(maxThreads);
+        this.executor = new ThreadPoolExecutor(
+                minSpareThreads,
+                maxThreads,
+                threadsMaxIdleTime,
+                TimeUnit.SECONDS,
+                new LinkedBlockingQueue<>()
+        );
     }
 
     private ServerSocket createServerSocket(final int port, final int acceptCount) {
@@ -71,7 +93,7 @@ public class Connector implements Runnable {
             return;
         }
         var processor = new Http11Processor(connection);
-        executor.submit(processor);
+        executor.execute(processor);
     }
 
     public void stop() {

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.apache.coyote.http11.Http11Processor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,17 +16,20 @@ public class Connector implements Runnable {
 
     private static final int DEFAULT_PORT = 8080;
     private static final int DEFAULT_ACCEPT_COUNT = 100;
+    private static final int DEFAULT_MAX_THREAD = 100;
 
     private final ServerSocket serverSocket;
+    private final ExecutorService executor;
     private boolean stopped;
 
     public Connector() {
-        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT);
+        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT, DEFAULT_MAX_THREAD);
     }
 
-    public Connector(final int port, final int acceptCount) {
+    public Connector(final int port, final int acceptCount, final int maxThreads) {
         this.serverSocket = createServerSocket(port, acceptCount);
         this.stopped = false;
+        this.executor = Executors.newFixedThreadPool(maxThreads);
     }
 
     private ServerSocket createServerSocket(final int port, final int acceptCount) {
@@ -66,7 +71,7 @@ public class Connector implements Runnable {
             return;
         }
         var processor = new Http11Processor(connection);
-        new Thread(processor).start();
+        executor.submit(processor);
     }
 
     public void stop() {

--- a/tomcat/src/main/java/org/apache/catalina/session/Session.java
+++ b/tomcat/src/main/java/org/apache/catalina/session/Session.java
@@ -1,12 +1,12 @@
 package org.apache.catalina.session;
 
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
 
 public class Session {
 
     private final String id;
-    private final Map<String, Object> values = new HashMap<>();
+    private final Map<String, Object> values = new ConcurrentHashMap<>();
 
     public Session(final String id) {
         this.id = id;

--- a/tomcat/src/main/java/org/apache/catalina/session/SessionManager.java
+++ b/tomcat/src/main/java/org/apache/catalina/session/SessionManager.java
@@ -1,12 +1,12 @@
 package org.apache.catalina.session;
 
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
 import org.apache.catalina.Manager;
 
 public class SessionManager implements Manager {
 
-    private static final Map<String, Session> SESSIONS = new HashMap<>();
+    private static final Map<String, Session> SESSIONS = new ConcurrentHashMap<>();
     private static final SessionManager INSTANCE = new SessionManager();
 
     private SessionManager() {

--- a/tomcat/src/test/java/org/apache/catalina/connector/ConnectorTest.java
+++ b/tomcat/src/test/java/org/apache/catalina/connector/ConnectorTest.java
@@ -21,10 +21,9 @@ class ConnectorTest {
     @Test
     void a() throws InterruptedException {
         int acceptCount = 3;
-        int maxThreads = 1;
         int requestCount = 10;
 
-        TestConnector testConnector = new TestConnector(TEST_PORT, acceptCount, maxThreads);
+        TestConnector testConnector = new TestConnector(TEST_PORT, acceptCount);
         testConnector.start();
 
         Thread[] requestThreads = new Thread[requestCount];

--- a/tomcat/src/test/java/org/apache/catalina/connector/ConnectorTest.java
+++ b/tomcat/src/test/java/org/apache/catalina/connector/ConnectorTest.java
@@ -13,9 +13,6 @@ class ConnectorTest {
 
     private static final int TEST_PORT = 8081;
     private static final String LOCALHOST = "127.0.0.1";
-    private static final int SERVER_PORT = 8080;
-    // acceptCount + maxThreads 보다 큰 값으로 설정
-    private static final int TOTAL_REQUESTS = 10;
 
     private static final Logger log = LoggerFactory.getLogger(ConnectorTest.class);
 

--- a/tomcat/src/test/java/org/apache/catalina/connector/ConnectorTest.java
+++ b/tomcat/src/test/java/org/apache/catalina/connector/ConnectorTest.java
@@ -1,0 +1,59 @@
+package org.apache.catalina.connector;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.Socket;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import support.TestConnector;
+
+class ConnectorTest {
+
+    private static final int TEST_PORT = 8081;
+    private static final String LOCALHOST = "127.0.0.1";
+    private static final int SERVER_PORT = 8080;
+    // acceptCount + maxThreads 보다 큰 값으로 설정
+    private static final int TOTAL_REQUESTS = 10;
+
+    private static final Logger log = LoggerFactory.getLogger(ConnectorTest.class);
+
+
+    @DisplayName("acceptCount가 작을 때 클라이언트가 연결에 실패할 수 있다.")
+    @Test
+    void a() throws InterruptedException {
+        int acceptCount = 3;
+        int maxThreads = 1;
+        int requestCount = 10;
+
+        TestConnector testConnector = new TestConnector(TEST_PORT, acceptCount, maxThreads);
+        testConnector.start();
+
+        Thread[] requestThreads = new Thread[requestCount];
+
+        for (int i = 0; i < requestCount; i++) {
+            final int num = i + 1;
+            requestThreads[i] = new Thread(
+                    () -> {
+                        log.info("{} 요청 시작", num);
+                        try (Socket socket = new Socket(LOCALHOST, TEST_PORT)) {
+                            log.info("[{}] ✅ 연결 성공", num);
+                        } catch (ConnectException e) {
+                            log.info("[{}] ❌ 연결 거부: {}", num, e.getMessage());
+                        } catch (IOException e) {
+                            log.info("[{}] ❌ 기타 오류", num);
+                        }
+                    }
+            );
+        }
+
+        for (int i = 0; i < requestCount; i++) {
+            requestThreads[i].start();
+        }
+
+        for (int i = 0; i < requestCount; i++) {
+            requestThreads[i].join();
+        }
+    }
+}

--- a/tomcat/src/test/java/support/TestConnector.java
+++ b/tomcat/src/test/java/support/TestConnector.java
@@ -1,0 +1,79 @@
+package support;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestConnector implements Runnable {
+
+    private static final Logger log = LoggerFactory.getLogger(TestConnector.class);
+
+    private final ServerSocket serverSocket;
+    private boolean stopped;
+
+    public TestConnector(final int port, final int acceptCount, final int maxThreads) {
+        this.serverSocket = createServerSocket(port, acceptCount);
+        this.stopped = false;
+    }
+
+    private ServerSocket createServerSocket(final int port, final int acceptCount) {
+        try {
+            return new ServerSocket(port, acceptCount);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public void start() {
+        var thread = new Thread(this);
+        thread.setDaemon(true);
+        thread.start();
+        stopped = false;
+        log.info("Web Application Server started {} port.", serverSocket.getLocalPort());
+    }
+
+    @Override
+    public void run() {
+        // 클라이언트가 연결될때까지 대기한다.
+        while (!stopped) {
+            connect();
+        }
+    }
+
+    private void connect() {
+        try {
+            Socket connection = serverSocket.accept();
+            process(connection);
+        } catch (IOException e) {
+            log.error(e.getMessage(), e);
+        }
+    }
+
+    private void process(final Socket connection) {
+        if (connection == null) {
+            return;
+        }
+
+        // 새 스레드 생성 대신 직접 처리 + 지연 추가
+//        try {
+//            Thread.sleep(1000); // 1초 대기
+//        } catch (InterruptedException e) {
+//            Thread.currentThread().interrupt();
+//        }
+        var processor = new TestHttp11Processor(connection);
+        processor.run();
+//        new Thread(processor).start();
+    }
+
+    public void stop() {
+        stopped = true;
+        try {
+            serverSocket.close();
+        } catch (IOException e) {
+            log.error(e.getMessage(), e);
+        }
+    }
+}

--- a/tomcat/src/test/java/support/TestConnector.java
+++ b/tomcat/src/test/java/support/TestConnector.java
@@ -14,7 +14,7 @@ public class TestConnector implements Runnable {
     private final ServerSocket serverSocket;
     private boolean stopped;
 
-    public TestConnector(final int port, final int acceptCount, final int maxThreads) {
+    public TestConnector(final int port, final int acceptCount) {
         this.serverSocket = createServerSocket(port, acceptCount);
         this.stopped = false;
     }

--- a/tomcat/src/test/java/support/TestHttp11Processor.java
+++ b/tomcat/src/test/java/support/TestHttp11Processor.java
@@ -1,0 +1,35 @@
+package support;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import org.apache.coyote.Processor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestHttp11Processor implements Runnable, Processor {
+
+    private static final Logger log = LoggerFactory.getLogger(TestHttp11Processor.class);
+    private final Socket connection;
+
+    public TestHttp11Processor(Socket connection) {
+        this.connection = connection;
+    }
+
+    @Override
+    public void run() {
+        process(connection);
+    }
+
+    @Override
+    public void process(final Socket connection) {
+        try (
+                final InputStream inputStream = connection.getInputStream();
+                final OutputStream outputStream = connection.getOutputStream()
+        ) {
+            Thread.sleep(3000);
+        } catch (final Exception e) {
+            log.error(e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
안녕하세요 시소 🙌 
조금 늦었습니다ㅎㅎ

### 리뷰 시 참고할 내용

test 클래스에 있는 것은 학습을 위해 작성한 것이니 제외하고 보셔도 무방합니다!

쓰레드 풀 관련 값은, 모두 [톰캣의 표준 값](https://tomcat.apache.org/tomcat-11.0-doc/config/http.html#Standard_Implementation)을 고려하여 설정했습니다.

```java
this.executor = new ThreadPoolExecutor(
        10, // corePoolSize -> minSpareThreads
        200, // maximumPoolSize -> maxThreads
        60, // keepAliveTime -> threadsMaxIdleTime
        TimeUnit.SECONDS, // unit
        new LinkedBlockingQueue<>() // workqueue
)
```

### 생각해보기 🤔
- acceptCount와 maxThreads는 각각 어떤 설정일까?
  - `acceptCount` : ServerSocket에 들어오는 요청들이 대기하는 Queue의 크기. Accept Queue의 connection을 ServrSocket의 accept() 메서드를 통해 획득할 수 있다. 
  - `maxThreads` : 스레드 큐의 최대 크기
- 최대 ThradPool의 크기는 250, 모든 Thread가 사용 중인(Busy) 상태이면 100명까지 대기 상태로 만들려면 어떻게 할까?
  - maxThreads: 250
  - accpetCount: 100

`acceptCount`가 무엇인지 파악하는 과정을 아래 블로그에 정리했습니다~!
https://yesjuhee.tistory.com/21
