### PR TITLE
[4단계 - 동시성 확장하기] 라젤(문선영) 미션 제출합니다. 

### DIFF
--- a/tomcat/src/main/java/com/techcourse/controller/LoginRequestController.java
+++ b/tomcat/src/main/java/com/techcourse/controller/LoginRequestController.java
@@ -36,8 +36,7 @@ public class LoginRequestController extends AbstractRequestController {
         Optional<Session> session = SessionManager.findById(httpRequest.getJSessionId());
 
         if (session.isPresent()) {
-            return HttpResponse.found(httpVersion, new Location("/index.html"), ContentType.APPLICATION_JSON,
-                    HttpCookie.empty());
+            return HttpResponse.found(httpVersion, new Location("/index.html"), HttpCookie.empty());
         }
         return HttpResponse.ok(httpVersion, ContentType.TEXT_HTML, ResponseBody.createBy(httpRequest));
     }
@@ -62,9 +61,8 @@ public class LoginRequestController extends AbstractRequestController {
             session.setAttribute("user", user);
             SessionManager.save(session);
             httpCookie.addSessionId(session.getId());
-            return HttpResponse.found(httpVersion, new Location("/index.html"), ContentType.APPLICATION_JSON,
-                    httpCookie);
+            return HttpResponse.found(httpVersion, new Location("/index.html"), httpCookie);
         }
-        return HttpResponse.found(httpVersion, new Location("/401.html"), ContentType.APPLICATION_JSON, httpCookie);
+        return HttpResponse.found(httpVersion, new Location("/401.html"), httpCookie);
     }
 }

--- a/tomcat/src/main/java/com/techcourse/controller/LoginRequestController.java
+++ b/tomcat/src/main/java/com/techcourse/controller/LoginRequestController.java
@@ -14,7 +14,7 @@ import org.apache.coyote.http.response.HttpResponse;
 import org.apache.coyote.http.response.Location;
 import org.apache.coyote.http.response.ResponseBody;
 import org.apache.coyote.http.session.Session;
-import org.apache.coyote.http.session.SessionRepository;
+import org.apache.coyote.http.session.SessionManager;
 
 public class LoginRequestController extends AbstractRequestController {
 
@@ -33,7 +33,7 @@ public class LoginRequestController extends AbstractRequestController {
     }
 
     private HttpResponse createGetLoginResponseBySession(final HttpRequest httpRequest) {
-        Optional<Session> session = SessionRepository.findById(httpRequest.getJSessionId());
+        Optional<Session> session = SessionManager.findById(httpRequest.getJSessionId());
 
         if (session.isPresent()) {
             return HttpResponse.found(httpVersion, new Location("/index.html"), ContentType.APPLICATION_JSON,
@@ -60,7 +60,7 @@ public class LoginRequestController extends AbstractRequestController {
         if (user.checkPassword(password)) {
             Session session = Session.newSession();
             session.setAttribute("user", user);
-            SessionRepository.save(session);
+            SessionManager.save(session);
             httpCookie.addSessionId(session.getId());
             return HttpResponse.found(httpVersion, new Location("/index.html"), ContentType.APPLICATION_JSON,
                     httpCookie);

--- a/tomcat/src/main/java/com/techcourse/controller/RegisterRequestController.java
+++ b/tomcat/src/main/java/com/techcourse/controller/RegisterRequestController.java
@@ -35,8 +35,7 @@ public class RegisterRequestController extends AbstractRequestController {
         if (httpRequest.hasEmptySessionId()) {
             responseCookie.addSessionId(String.valueOf(UUID.randomUUID()));
         }
-        return HttpResponse.found(httpVersion, new Location("/index.html"), ContentType.APPLICATION_JSON,
-                responseCookie);
+        return HttpResponse.found(httpVersion, new Location("/index.html"), responseCookie);
     }
 
     private void registerUser(final Map<String, String> requestBodies) {

--- a/tomcat/src/main/java/com/techcourse/controller/RequestMapping.java
+++ b/tomcat/src/main/java/com/techcourse/controller/RequestMapping.java
@@ -6,25 +6,31 @@ import org.apache.coyote.http.request.HttpRequest;
 
 public class RequestMapping {
 
-    private final HttpVersion httpVersion;
+    private final RootRequestController rootRequestController;
+    private final LoginRequestController loginRequestController;
+    private final RegisterRequestController registerRequestController;
+    private final StaticResourceRequestController staticResourceRequestController;
 
     public RequestMapping(final HttpVersion httpVersion) {
-        this.httpVersion = httpVersion;
+        this.rootRequestController = new RootRequestController(httpVersion);
+        this.loginRequestController = new LoginRequestController(httpVersion);
+        this.registerRequestController = new RegisterRequestController(httpVersion);
+        this.staticResourceRequestController = new StaticResourceRequestController(httpVersion);
     }
 
     public RequestController getRequestController(final HttpRequest httpRequest) {
         if (httpRequest.isRootPath()) {
-            return new RootRequestController(httpVersion);
+            return rootRequestController;
         }
 
         if (httpRequest.getFilePath().equals("/login.html")) {
-            return new LoginRequestController(httpVersion);
+            return loginRequestController;
         }
 
         if (httpRequest.getFilePath().equals("/register.html")) {
-            return new RegisterRequestController(httpVersion);
+            return registerRequestController;
         }
 
-        return new StaticResourceRequestController(httpVersion);
+        return staticResourceRequestController;
     }
 }

--- a/tomcat/src/main/java/com/techcourse/controller/core/AbstractRequestController.java
+++ b/tomcat/src/main/java/com/techcourse/controller/core/AbstractRequestController.java
@@ -8,7 +8,7 @@ import org.apache.coyote.http.response.HttpResponse;
 public abstract class AbstractRequestController implements RequestController {
 
     @Override
-    public HttpResponse service(HttpRequest httpRequest) {
+    public final HttpResponse service(HttpRequest httpRequest) {
         HttpMethod httpMethod = httpRequest.getHttpMethod();
 
         if (httpMethod == HttpMethod.GET) {

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -1,13 +1,15 @@
 package org.apache.catalina.connector;
 
-import org.apache.coyote.http11.Http11Processor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.apache.coyote.http11.Http11Processor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Connector implements Runnable {
 
@@ -15,17 +17,20 @@ public class Connector implements Runnable {
 
     private static final int DEFAULT_PORT = 8080;
     private static final int DEFAULT_ACCEPT_COUNT = 100;
+    private static final int DEFAULT_MAX_THREADS = 200;
 
     private final ServerSocket serverSocket;
+    private final ExecutorService executorService;
     private boolean stopped;
 
     public Connector() {
-        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT);
+        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT, DEFAULT_MAX_THREADS);
     }
 
-    public Connector(final int port, final int acceptCount) {
+    public Connector(final int port, final int acceptCount, final int maxThreads) {
         this.serverSocket = createServerSocket(port, acceptCount);
         this.stopped = false;
+        this.executorService = Executors.newFixedThreadPool(maxThreads);
     }
 
     private ServerSocket createServerSocket(final int port, final int acceptCount) {
@@ -41,7 +46,7 @@ public class Connector implements Runnable {
     public void start() {
         var thread = new Thread(this);
         thread.setDaemon(true);
-        thread.start();
+        thread.start(); // Connector 실행용 스레드
         stopped = false;
         log.info("Web Application Server started {} port.", serverSocket.getLocalPort());
     }
@@ -67,15 +72,24 @@ public class Connector implements Runnable {
             return;
         }
         var processor = new Http11Processor(connection);
-        new Thread(processor).start();
+        executorService.execute(processor); // ThreadPool 개수 안에서 실행
     }
 
     public void stop() {
         stopped = true;
         try {
+            executorService.shutdown(); // 새로운 작업 제출을 막고 기존 작업 종료 대기 시작
+
+            if (executorService.awaitTermination(60, TimeUnit.SECONDS)) { // 작업 종료 대기
+                executorService.shutdownNow(); // 대기해도 종료 안되면 강제 셧다운
+            }
+
             serverSocket.close();
         } catch (IOException e) {
             log.error(e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt(); // 상태 복원
+            log.warn("인터럽트 발생! (정상 종료 신호 가능성 있음)");
         }
     }
 

--- a/tomcat/src/main/java/org/apache/coyote/http/request/HttpRequest.java
+++ b/tomcat/src/main/java/org/apache/coyote/http/request/HttpRequest.java
@@ -1,128 +1,47 @@
 package org.apache.coyote.http.request;
 
-import com.techcourse.exception.UncheckedServletException;
+import java.util.Map;
+import java.util.Objects;
 import org.apache.coyote.http.ContentType;
 import org.apache.coyote.http.HttpCookie;
 import org.apache.coyote.http.HttpMethod;
 import org.apache.coyote.http.HttpVersion;
-import java.util.Map;
-import java.util.Objects;
 
 public class HttpRequest {
 
-    private static final String REQUEST_LINE_DELIMITER = " ";
-    private static final String QUERY_STRING_DELIMITER = "?";
     private static final String EXTENSION_DELIMITER = ".";
     private static final String ROOT_PATH = "/";
-    private static final String EMPTY = "";
     private static final String DEFAULT_EXTENSION = ".html";
 
-    private static final int METHOD_INDEX = 0;
-    private static final int URI_INDEX = 1;
-    private static final int VERSION_INDEX = 2;
-    private static final int REQUEST_LINE_PARTS = 3;
     private static final int NOT_FOUND_INDEX = -1;
 
-    private final HttpMethod httpMethod;
-    private final String path;
-    private final RequestParams requestParams;
+    private final RequestLine requestLine;
     private final ContentType contentType;
     private final RequestHeader requestHeader;
     private final HttpCookie httpCookie;
     private final RequestBody requestBody;
-    private final HttpVersion httpVersion;
 
-    public HttpRequest(final HttpMethod httpMethod,
-                       final String path,
-                       final RequestParams requestParams,
+    public HttpRequest(final RequestLine requestLine,
                        final ContentType contentType,
                        final RequestHeader requestHeader,
                        final HttpCookie httpCookie,
-                       final RequestBody requestBody,
-                       final HttpVersion httpVersion
+                       final RequestBody requestBody
     ) {
-        this.httpMethod = httpMethod;
-        this.path = path;
-        this.requestParams = requestParams;
+        this.requestLine = requestLine;
         this.contentType = contentType;
         this.requestHeader = requestHeader;
         this.httpCookie = httpCookie;
         this.requestBody = requestBody;
-        this.httpVersion = httpVersion;
     }
 
-    public static HttpRequest of(final String requestHeaderFirstLine,
+    public static HttpRequest of(final RequestLine requestLine,
                                  final RequestHeader requestHeader,
                                  final RequestBody requestBody) {
-        String[] requestLineValues = splitRequestLine(requestHeaderFirstLine);
 
-        String requestMethod = requestLineValues[METHOD_INDEX];
-        String requestUri = requestLineValues[URI_INDEX];
-        String requestProtocolVersion = requestLineValues[VERSION_INDEX];
-
-        HttpMethod httpMethod = HttpMethod.from(requestMethod);
-
-        String path = extractPath(requestUri);
-        String queryString = extractQueryString(requestUri);
-
-        RequestParams requestParams = RequestParams.from(queryString);
-        ContentType contentType = extractContentType(path);
+        ContentType contentType = extractContentType(requestLine.getPath());
         HttpCookie httpCookie = HttpCookie.from(requestHeader.getCookie());
 
-        HttpVersion httpVersion = HttpVersion.from(requestProtocolVersion);
-
-        return new HttpRequest(httpMethod, path, requestParams, contentType, requestHeader, httpCookie, requestBody,
-                httpVersion);
-    }
-
-    private static String[] splitRequestLine(final String requestLine) {
-        validateNullRequestLine(requestLine);
-        String[] requestLineValues = requestLine.split(REQUEST_LINE_DELIMITER);
-        validateRequestLineFormat(requestLineValues);
-        return requestLineValues;
-    }
-
-    private static void validateNullRequestLine(final String requestLine) {
-        if (requestLine == null) {
-            throw new UncheckedServletException("request line은 null이 될 수 없습니다.");
-        }
-    }
-
-    private static void validateRequestLineFormat(final String[] requestLineValues) {
-        if (requestLineValues.length != REQUEST_LINE_PARTS) {
-            throw new UncheckedServletException("올바르지 않은 요청 형식입니다.");
-        }
-    }
-
-    private static String extractPath(final String requestUri) {
-        int queryStringDelimiterIndex = findQueryStringDelimiterIndex(requestUri);
-
-        if (hasExtension(queryStringDelimiterIndex)) {
-            return requestUri.substring(0, queryStringDelimiterIndex);
-        }
-
-        return requestUri;
-    }
-
-    private static String extractQueryString(final String requestUri) {
-        int queryStringDelimiterIndex = findQueryStringDelimiterIndex(requestUri);
-
-        if (hasExtension(queryStringDelimiterIndex)) {
-            return requestUri.substring(queryStringDelimiterIndex + 1);
-        }
-
-        return EMPTY;
-    }
-
-    private static int findQueryStringDelimiterIndex(final String uri) {
-        int firstIndex = uri.indexOf(QUERY_STRING_DELIMITER);
-        int lastIndex = uri.lastIndexOf(QUERY_STRING_DELIMITER);
-
-        if (hasExtension(firstIndex) && firstIndex != lastIndex) {
-            throw new UncheckedServletException("잘못된 URI 형식: ?가 여러 번 포함되었습니다 → " + uri);
-        }
-
-        return firstIndex;
+        return new HttpRequest(requestLine, contentType, requestHeader, httpCookie, requestBody);
     }
 
     private static ContentType extractContentType(final String path) {
@@ -141,14 +60,11 @@ public class HttpRequest {
     }
 
     public String getFilePath() {
-        if (path.contains(EXTENSION_DELIMITER)) {
-            return path;
-        }
-        return path + DEFAULT_EXTENSION;
+        return requestLine.getFilePath();
     }
 
     public boolean isRootPath() {
-        return path.equals(ROOT_PATH);
+        return requestLine.isRootPath();
     }
 
     public boolean hasEmptySessionId() {
@@ -156,11 +72,11 @@ public class HttpRequest {
     }
 
     public HttpMethod getHttpMethod() {
-        return httpMethod;
+        return requestLine.getHttpMethod();
     }
 
     public Map<String, String> getRequestParams() {
-        return requestParams.queryParameters();
+        return requestLine.getRequestParams();
     }
 
     public ContentType getContentType() {
@@ -176,6 +92,6 @@ public class HttpRequest {
     }
 
     public HttpVersion getHttpVersion() {
-        return httpVersion;
+        return requestLine.getHttpVersion();
     }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http/request/RequestLine.java
+++ b/tomcat/src/main/java/org/apache/coyote/http/request/RequestLine.java
@@ -1,0 +1,134 @@
+package org.apache.coyote.http.request;
+
+import com.techcourse.exception.UncheckedServletException;
+import java.util.Map;
+import org.apache.coyote.http.HttpMethod;
+import org.apache.coyote.http.HttpVersion;
+
+public class RequestLine {
+    private static final String REQUEST_LINE_DELIMITER = " ";
+    private static final String QUERY_STRING_DELIMITER = "?";
+    private static final String EXTENSION_DELIMITER = ".";
+    private static final String DEFAULT_EXTENSION = ".html";
+    private static final String ROOT_PATH = "/";
+    private static final String EMPTY = "";
+
+    private static final int REQUEST_LINE_PARTS = 3;
+    private static final int NOT_FOUND_INDEX = -1;
+    private static final int VERSION_INDEX = 2;
+    private static final int METHOD_INDEX = 0;
+    private static final int URI_INDEX = 1;
+
+    private final HttpMethod httpMethod;
+    private final String path;
+    private final RequestParams requestParams;
+    private final HttpVersion httpVersion;
+
+    public RequestLine(final HttpMethod httpMethod,
+                       final String path,
+                       final RequestParams requestParams,
+                       final HttpVersion httpVersion) {
+        this.httpMethod = httpMethod;
+        this.path = path;
+        this.requestParams = requestParams;
+        this.httpVersion = httpVersion;
+    }
+
+    public static RequestLine from(final String requestHeaderFirstLine) {
+        String[] requestLineValues = splitRequestLine(requestHeaderFirstLine);
+
+        String requestMethod = requestLineValues[METHOD_INDEX];
+        String requestUri = requestLineValues[URI_INDEX];
+        String requestProtocolVersion = requestLineValues[VERSION_INDEX];
+
+        HttpMethod httpMethod = HttpMethod.from(requestMethod);
+        String path = extractPath(requestUri);
+        String queryString = extractQueryString(requestUri);
+        RequestParams requestParams = RequestParams.from(queryString);
+
+        HttpVersion httpVersion = HttpVersion.from(requestProtocolVersion);
+
+        return new RequestLine(httpMethod, path, requestParams, httpVersion);
+    }
+
+    private static String[] splitRequestLine(final String requestLine) {
+        validateNullRequestLine(requestLine);
+        String[] requestLineValues = requestLine.split(REQUEST_LINE_DELIMITER);
+        validateRequestLineFormat(requestLineValues);
+        return requestLineValues;
+    }
+
+    private static void validateNullRequestLine(final String requestLine) {
+        if (requestLine == null) {
+            throw new UncheckedServletException("request line은 null이 될 수 없습니다.");
+        }
+    }
+
+    private static void validateRequestLineFormat(final String[] requestLineValues) {
+        if (requestLineValues.length != REQUEST_LINE_PARTS) {
+            throw new UncheckedServletException("올바르지 않은 요청 형식입니다.");
+        }
+    }
+
+    private static String extractPath(final String requestUri) {
+        int queryStringDelimiterIndex = findQueryStringDelimiterIndex(requestUri);
+
+        if (hasExtension(queryStringDelimiterIndex)) {
+            return requestUri.substring(0, queryStringDelimiterIndex);
+        }
+
+        return requestUri;
+    }
+
+    private static String extractQueryString(final String requestUri) {
+        int queryStringDelimiterIndex = findQueryStringDelimiterIndex(requestUri);
+
+        if (hasExtension(queryStringDelimiterIndex)) {
+            return requestUri.substring(queryStringDelimiterIndex + 1);
+        }
+
+        return EMPTY;
+    }
+
+    private static int findQueryStringDelimiterIndex(final String uri) {
+        int firstIndex = uri.indexOf(QUERY_STRING_DELIMITER);
+        int lastIndex = uri.lastIndexOf(QUERY_STRING_DELIMITER);
+
+        if (hasExtension(firstIndex) && firstIndex != lastIndex) {
+            throw new UncheckedServletException("잘못된 URI 형식: ?가 여러 번 포함되었습니다 → " + uri);
+        }
+
+        return firstIndex;
+    }
+
+    private static boolean hasExtension(int delimiterIndex) {
+        return delimiterIndex != NOT_FOUND_INDEX;
+    }
+
+    public String getFilePath() {
+        if (path.contains(EXTENSION_DELIMITER)) {
+            return path;
+        }
+        return path + DEFAULT_EXTENSION;
+    }
+
+    public boolean isRootPath() {
+        return path.equals(ROOT_PATH);
+    }
+
+    public HttpMethod getHttpMethod() {
+        return httpMethod;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public Map<String, String> getRequestParams() {
+        return requestParams.queryParameters();
+    }
+
+    public HttpVersion getHttpVersion() {
+        return httpVersion;
+    }
+}

--- a/tomcat/src/main/java/org/apache/coyote/http/response/HttpResponse.java
+++ b/tomcat/src/main/java/org/apache/coyote/http/response/HttpResponse.java
@@ -45,10 +45,9 @@ public class HttpResponse {
     }
 
     public static HttpResponse found(
-            final HttpVersion httpVersion, final Location location, final ContentType contentType,
-            final HttpCookie httpCookie
+            final HttpVersion httpVersion, final Location location, final HttpCookie httpCookie
     ) {
-        return new HttpResponse(httpVersion, HttpStatus.FOUND, location, contentType, httpCookie,
+        return new HttpResponse(httpVersion, HttpStatus.FOUND, location, null, httpCookie,
                 ResponseBody.empty());
     }
 
@@ -60,9 +59,12 @@ public class HttpResponse {
         List<String> lines = new ArrayList<>();
 
         lines.add(httpVersion.toProtocolString() + " " + httpStatus.toStatusLine() + " ");
-        lines.add(contentType.toHeaderLine() + " ");
-        lines.add(responseBody.toContentLengthHeaderLine() + " ");
-
+        if (contentType != null) {
+            lines.add(contentType.toHeaderLine() + " ");
+        }
+        if (!responseBody.isEmpty()) {
+            lines.add(responseBody.toContentLengthHeaderLine() + " ");
+        }
         if (!location.isEmpty()) {
             lines.add(location.toHttpHeaderFormat());
         }
@@ -71,7 +73,9 @@ public class HttpResponse {
         }
 
         lines.add("");
-        lines.add(responseBody.value());
+        if (!responseBody.isEmpty()) {
+            lines.add(responseBody.value());
+        }
 
         return String.join("\r\n", lines);
     }

--- a/tomcat/src/main/java/org/apache/coyote/http/response/ResponseBody.java
+++ b/tomcat/src/main/java/org/apache/coyote/http/response/ResponseBody.java
@@ -30,4 +30,8 @@ public record ResponseBody(
 
         return "Content-Length: " + contentLength;
     }
+
+    public boolean isEmpty() {
+        return value.isEmpty();
+    }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http/session/SessionManager.java
+++ b/tomcat/src/main/java/org/apache/coyote/http/session/SessionManager.java
@@ -4,7 +4,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class SessionRepository {
+public class SessionManager {
     private static final Map<String, Session> SESSIONS = new ConcurrentHashMap<>();
 
     public static void save(final Session session) {

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -20,6 +20,7 @@ import org.apache.coyote.http.HttpVersion;
 import org.apache.coyote.http.request.HttpRequest;
 import org.apache.coyote.http.request.RequestBody;
 import org.apache.coyote.http.request.RequestHeader;
+import org.apache.coyote.http.request.RequestLine;
 import org.apache.coyote.http.response.HttpResponse;
 import org.apache.coyote.http.response.Location;
 import org.slf4j.Logger;
@@ -50,10 +51,11 @@ public class Http11Processor implements Runnable, Processor {
              final OutputStream outputStream = connection.getOutputStream()
         ) {
             try {
-                String requestLine = bufferedReader.readLine();
+                String requestLineString = bufferedReader.readLine();
                 RequestHeader requestHeader = RequestHeader.from(parseRequestHeader(bufferedReader));
                 RequestBody requestBody = parseRequestBody(bufferedReader, requestHeader);
 
+                RequestLine requestLine = RequestLine.from(requestLineString);
                 HttpRequest httpRequest = HttpRequest.of(requestLine, requestHeader, requestBody);
                 RequestController requestController = requestMapping.getRequestController(httpRequest);
 

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -14,7 +14,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.coyote.Processor;
-import org.apache.coyote.http.ContentType;
 import org.apache.coyote.http.HttpCookie;
 import org.apache.coyote.http.HttpVersion;
 import org.apache.coyote.http.request.HttpRequest;
@@ -104,8 +103,7 @@ public class Http11Processor implements Runnable, Processor {
     }
 
     private void redirectToErrorPage(final OutputStream outputStream, final Location location) throws IOException {
-        HttpResponse errorResponse = HttpResponse.found(HttpVersion.HTTP_1_1, location, ContentType.TEXT_HTML,
-                HttpCookie.empty());
+        HttpResponse errorResponse = HttpResponse.found(HttpVersion.HTTP_1_1, location, HttpCookie.empty());
         outputStream.write(errorResponse.toBytes());
         outputStream.flush();
     }

--- a/tomcat/src/test/java/com/techcourse/controller/LoginRequestControllerTest.java
+++ b/tomcat/src/test/java/com/techcourse/controller/LoginRequestControllerTest.java
@@ -11,6 +11,7 @@ import org.apache.coyote.http.HttpVersion;
 import org.apache.coyote.http.request.HttpRequest;
 import org.apache.coyote.http.request.RequestBody;
 import org.apache.coyote.http.request.RequestHeader;
+import org.apache.coyote.http.request.RequestLine;
 import org.apache.coyote.http.response.HttpResponse;
 import org.apache.coyote.http.session.Session;
 import org.apache.coyote.http.session.SessionRepository;
@@ -31,7 +32,8 @@ class LoginRequestControllerTest {
     @Test
     void serviceTest1() {
         // given
-        String requestLine = "GET /login.html HTTP/1.1";
+        String requestLineString = "GET /login.html HTTP/1.1";
+        RequestLine requestLine = RequestLine.from(requestLineString);
         RequestHeader requestHeader = RequestHeader.from(List.of("Host: localhost:8080"));
         RequestBody requestBody = RequestBody.empty();
         HttpRequest httpRequest = HttpRequest.of(requestLine, requestHeader, requestBody);
@@ -52,7 +54,8 @@ class LoginRequestControllerTest {
         Session session = Session.newSession();
         SessionRepository.save(session);
 
-        String requestLine = "GET /login.html HTTP/1.1";
+        String requestLineString = "GET /login.html HTTP/1.1";
+        RequestLine requestLine = RequestLine.from(requestLineString);
         RequestHeader requestHeader = RequestHeader.from(List.of(
                 "Host: localhost:8080",
                 "Cookie: JSESSIONID=" + session.getId()
@@ -73,7 +76,8 @@ class LoginRequestControllerTest {
     @Test
     void serviceTest3() {
         // given
-        String requestLine = "POST /login HTTP/1.1";
+        String requestLineString = "POST /login HTTP/1.1";
+        RequestLine requestLine = RequestLine.from(requestLineString);
         RequestHeader requestHeader = RequestHeader.from(List.of(
                 "Host: localhost:8080",
                 "Content-Type: application/x-www-form-urlencoded",
@@ -99,7 +103,8 @@ class LoginRequestControllerTest {
     @Test
     void serviceTest4() {
         // given
-        String requestLine = "POST /login HTTP/1.1";
+        String requestLineString = "POST /login HTTP/1.1";
+        RequestLine requestLine = RequestLine.from(requestLineString);
         RequestHeader requestHeader = RequestHeader.from(List.of(
                 "Host: localhost:8080",
                 "Content-Type: application/x-www-form-urlencoded",
@@ -121,7 +126,8 @@ class LoginRequestControllerTest {
     @Test
     void serviceTest5() {
         // given
-        String requestLine = "POST /login HTTP/1.1";
+        String requestLineString = "POST /login HTTP/1.1";
+        RequestLine requestLine = RequestLine.from(requestLineString);
         RequestHeader requestHeader = RequestHeader.from(List.of(
                 "Host: localhost:8080",
                 "Content-Type: application/x-www-form-urlencoded",
@@ -140,7 +146,8 @@ class LoginRequestControllerTest {
     @Test
     void serviceTest6() {
         // given
-        String requestLine = "PUT /login HTTP/1.1";
+        String requestLineString = "PUT /login HTTP/1.1";
+        RequestLine requestLine = RequestLine.from(requestLineString);
         RequestHeader requestHeader = RequestHeader.from(List.of("Host: localhost:8080"));
         RequestBody requestBody = RequestBody.empty();
         HttpRequest httpRequest = HttpRequest.of(requestLine, requestHeader, requestBody);

--- a/tomcat/src/test/java/com/techcourse/controller/LoginRequestControllerTest.java
+++ b/tomcat/src/test/java/com/techcourse/controller/LoginRequestControllerTest.java
@@ -14,7 +14,7 @@ import org.apache.coyote.http.request.RequestHeader;
 import org.apache.coyote.http.request.RequestLine;
 import org.apache.coyote.http.response.HttpResponse;
 import org.apache.coyote.http.session.Session;
-import org.apache.coyote.http.session.SessionRepository;
+import org.apache.coyote.http.session.SessionManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -52,7 +52,7 @@ class LoginRequestControllerTest {
     void serviceTest2() {
         // given
         Session session = Session.newSession();
-        SessionRepository.save(session);
+        SessionManager.save(session);
 
         String requestLineString = "GET /login.html HTTP/1.1";
         RequestLine requestLine = RequestLine.from(requestLineString);

--- a/tomcat/src/test/java/com/techcourse/controller/RegisterRequestControllerTest.java
+++ b/tomcat/src/test/java/com/techcourse/controller/RegisterRequestControllerTest.java
@@ -11,6 +11,7 @@ import org.apache.coyote.http.HttpVersion;
 import org.apache.coyote.http.request.HttpRequest;
 import org.apache.coyote.http.request.RequestBody;
 import org.apache.coyote.http.request.RequestHeader;
+import org.apache.coyote.http.request.RequestLine;
 import org.apache.coyote.http.response.HttpResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -29,7 +30,8 @@ class RegisterRequestControllerTest {
     @Test
     void serviceTest1() {
         // given
-        String requestLine = "GET /register.html HTTP/1.1";
+        String requestLineString = "GET /register.html HTTP/1.1";
+        RequestLine requestLine = RequestLine.from(requestLineString);
         RequestHeader requestHeader = RequestHeader.from(List.of("Host: localhost:8080"));
         RequestBody requestBody = RequestBody.empty();
         HttpRequest httpRequest = HttpRequest.of(requestLine, requestHeader, requestBody);
@@ -47,7 +49,8 @@ class RegisterRequestControllerTest {
     @Test
     void serviceTest2() {
         // given
-        String requestLine = "POST /register HTTP/1.1";
+        String requestLineString = "POST /register HTTP/1.1";
+        RequestLine requestLine = RequestLine.from(requestLineString);
         RequestHeader requestHeader = RequestHeader.from(List.of(
                 "Host: localhost:8080",
                 "Content-Type: application/x-www-form-urlencoded",
@@ -73,7 +76,8 @@ class RegisterRequestControllerTest {
     @Test
     void serviceTest3() {
         // given
-        String requestLine = "PUT /register HTTP/1.1";
+        String requestLineString = "PUT /register HTTP/1.1";
+        RequestLine requestLine = RequestLine.from(requestLineString);
         RequestHeader requestHeader = RequestHeader.from(List.of("Host: localhost:8080"));
         RequestBody requestBody = RequestBody.empty();
         HttpRequest httpRequest = HttpRequest.of(requestLine, requestHeader, requestBody);
@@ -88,7 +92,8 @@ class RegisterRequestControllerTest {
     @Test
     void serviceTest4() {
         // given
-        String requestLine = "POST /register HTTP/1.1";
+        String requestLineString = "POST /register HTTP/1.1";
+        RequestLine requestLine = RequestLine.from(requestLineString);
         RequestHeader requestHeader = RequestHeader.from(List.of(
                 "Host: localhost:8080",
                 "Content-Type: application/x-www-form-urlencoded",

--- a/tomcat/src/test/java/com/techcourse/http/request/HttpRequestTest.java
+++ b/tomcat/src/test/java/com/techcourse/http/request/HttpRequestTest.java
@@ -1,17 +1,16 @@
 package com.techcourse.http.request;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.techcourse.exception.UncheckedServletException;
+import java.util.List;
 import org.apache.coyote.http.ContentType;
 import org.apache.coyote.http.HttpMethod;
 import org.apache.coyote.http.HttpVersion;
-import java.util.List;
 import org.apache.coyote.http.request.HttpRequest;
 import org.apache.coyote.http.request.RequestBody;
 import org.apache.coyote.http.request.RequestHeader;
+import org.apache.coyote.http.request.RequestLine;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -21,7 +20,8 @@ class HttpRequestTest {
     @Test
     void ofTest1() {
         // given
-        String requestLine = "POST /register HTTP/1.1";
+        String requestLineString = "POST /register HTTP/1.1";
+        RequestLine requestLine = RequestLine.from(requestLineString);
         RequestHeader requestHeader = RequestHeader.from(List.of(
                 "Host: localhost:8080",
                 "Content-Type: application/x-www-form-urlencoded",
@@ -48,7 +48,8 @@ class HttpRequestTest {
     @Test
     void ofTest2() {
         // given
-        String requestLine = "GET /search?name=java&category=programming HTTP/1.1";
+        String requestLineString = "GET /search?name=java&category=programming HTTP/1.1";
+        RequestLine requestLine = RequestLine.from(requestLineString);
         RequestHeader requestHeader = RequestHeader.from(List.of("Host: localhost:8080"));
         RequestBody requestBody = RequestBody.empty();
 
@@ -68,7 +69,8 @@ class HttpRequestTest {
     @Test
     void ofTest3() {
         // given
-        String requestLine = "GET / HTTP/1.1";
+        String requestLineString = "GET / HTTP/1.1";
+        RequestLine requestLine = RequestLine.from(requestLineString);
         RequestHeader requestHeader = RequestHeader.from(List.of("Host: localhost:8080"));
         RequestBody requestBody = RequestBody.empty();
 
@@ -84,7 +86,8 @@ class HttpRequestTest {
     @Test
     void ofTest4() {
         // given
-        String requestLine = "GET /index.html HTTP/1.1";
+        String requestLineString = "GET /index.html HTTP/1.1";
+        RequestLine requestLine = RequestLine.from(requestLineString);
         RequestHeader requestHeader = RequestHeader.from(List.of(
                 "Host: localhost:8080",
                 "Cookie: JSESSIONID=abc123; theme=dark"
@@ -99,39 +102,12 @@ class HttpRequestTest {
         assertThat(httpRequest.hasEmptySessionId()).isFalse();
     }
 
-    @DisplayName("잘못된 요청 라인 형식인 경우")
-    @Test
-    void ofTest5() {
-        // given
-        String invalidRequestLine = "GET /index.html";
-        RequestHeader requestHeader = RequestHeader.from(List.of());
-        RequestBody requestBody = RequestBody.empty();
-
-        // when & then
-        assertThatThrownBy(() -> HttpRequest.of(invalidRequestLine, requestHeader, requestBody))
-                .isInstanceOf(UncheckedServletException.class)
-                .hasMessage("올바르지 않은 요청 형식입니다.");
-    }
-
-    @DisplayName("여러 개의 물음표가 있는 url의 경우")
-    @Test
-    void ofTest6() {
-        // given
-        String requestLine = "GET /search?name=java?category=programming HTTP/1.1";
-        RequestHeader requestHeader = RequestHeader.from(List.of());
-        RequestBody requestBody = RequestBody.empty();
-
-        // when & then
-        assertThatThrownBy(() -> HttpRequest.of(requestLine, requestHeader, requestBody))
-                .isInstanceOf(UncheckedServletException.class)
-                .hasMessage("잘못된 URI 형식: ?가 여러 번 포함되었습니다 → /search?name=java?category=programming");
-    }
-
     @DisplayName("확장자가 없는 경로에 기본 확장자 추가")
     @Test
     void getFilePathTest1() {
         // given
-        String requestLine = "GET /index HTTP/1.1";
+        String requestLineString = "GET /index HTTP/1.1";
+        RequestLine requestLine = RequestLine.from(requestLineString);
         RequestHeader requestHeader = RequestHeader.from(List.of());
         RequestBody requestBody = RequestBody.empty();
 
@@ -146,7 +122,8 @@ class HttpRequestTest {
     @Test
     void getFilePathTest2() {
         // given
-        String requestLine = "GET /styles.css HTTP/1.1";
+        String requestLineString = "GET /styles.css HTTP/1.1";
+        RequestLine requestLine = RequestLine.from(requestLineString);
         RequestHeader requestHeader = RequestHeader.from(List.of());
         RequestBody requestBody = RequestBody.empty();
 

--- a/tomcat/src/test/java/com/techcourse/http/response/HttpResponseTest.java
+++ b/tomcat/src/test/java/com/techcourse/http/response/HttpResponseTest.java
@@ -56,7 +56,7 @@ class HttpResponseTest {
         HttpCookie httpCookie = HttpCookie.empty();
 
         // when
-        HttpResponse httpResponse = HttpResponse.found(httpVersion, location, ContentType.APPLICATION_JSON, httpCookie);
+        HttpResponse httpResponse = HttpResponse.found(httpVersion, location, httpCookie);
 
         // then
         assertThat(httpResponse).isNotNull();
@@ -110,27 +110,10 @@ class HttpResponseTest {
         HttpCookie httpCookie = HttpCookie.empty();
 
         // when
-        HttpResponse httpResponse = HttpResponse.found(httpVersion, location, ContentType.APPLICATION_JSON, httpCookie);
+        HttpResponse httpResponse = HttpResponse.found(httpVersion, location, httpCookie);
 
         // then
         String responseString = new String(httpResponse.toBytes());
         assertThat(responseString).doesNotContain("Location:");
-    }
-
-    @DisplayName("빈 응답인 경우")
-    @Test
-    void toBytesTest4() {
-        // given
-        HttpVersion httpVersion = HttpVersion.HTTP_1_1;
-        ContentType contentType = ContentType.TEXT_HTML;
-        ResponseBody responseBody = ResponseBody.empty();
-
-        // when
-        HttpResponse httpResponse = HttpResponse.ok(httpVersion, contentType, responseBody);
-
-        // then
-        String responseString = new String(httpResponse.toBytes());
-        assertThat(responseString).contains("Content-Length: 0");
-        assertThat(responseString).endsWith("\r\n\r\n");
     }
 }


### PR DESCRIPTION
안녕하세요! 포스티~ 👋

드디어 step4 리뷰 요청 드립니다. 🥳
저번에 리뷰해주신 부분들을 반영하였고 이번 step4 요구사항을 구현해 보았습니다!
읽어보시고 천천히 리뷰해주셔도 됩니다! 👍

# 저번 리뷰 반영 사항

### Request Mapping 관련 리뷰
> 컨트롤러 매핑이 좋네요 👍
> 
> 한가지 의견을 드리자면 현재 각 Controller들을 매번 new 키워드로 새로운 인스턴스를 생성해서 반환하고 있어요
> 각 컨트롤러들을 보면 상태를 공유하는 필드가 없어서 여기에 1개의 인스턴스들을 미리 생성해두고 요청이 들어오면 매번 같은 컨트롤러 인스턴스를 재활용하는 방안도 고려해볼 수 있을것 같아요

➡️ 말씀해 주신 것 처럼 1개의 인스턴스들을 미리 생성해두어서 요청이 들어오면 매번 같은 컨트롤러 인스턴스를 재활용할 수 있게끔 수정하였습니다!

### HttpRequest 관련 리뷰
> 헤더와 바디도 포장했으니 RequestLine도 포장하면 좋을것 같아요 👍
> 
> 저희 LMS step3 힌트에도 나와있답니다!

➡️ RequestLine을 포장하도록 수정하였습니다! 

### 리다이렉션 응답 관련 리뷰
> 302 Found 리다이렉션 응답의 content-type을 application/json으로 지정하신 이유가 있을까요??
> 
> 제가 알기로는 302 응답이 오면 브라우저들은 대부분 body를 무시하고 Location 헤더로 리다이렉션을 진행하는데, 어떤 이유가 있어서 해당 타입을 설정하신 것일까요??

➡️ 말씀해주신 부분 인지하고 있었습니다!
302 응답은 브라우저에서 body가 무시되기 때문에 Content-Type 지정이 꼭 필요하지 않지만, 응답 포맷을 일관되게 유지하려는 의도에서 JSON 타입을 지정했었습니다.
하지만 오히려 JSON 타입을 지정하는 것이 불필요한 혼동을 줄 수 있어, 
말씀 주신 방향대로 Content-Type을 설정하지 않는 방향을 수정하였습니다!

### HttpCookie의 ConcurrentHashMap 관련 리뷰
> ConcurrentHashMap에서 HashMap으로 돌아왔네요!
> 
> 이유가 있을까요??

➡️ https://github.com/woowacourse/java-http/pull/1008 : 저번 pr에서 답을 작성했었습니다!