### PR TITLE
[4단계 - 동시성 확장하기] 시소(이경민) 미션 제출합니다.

### DIFF
--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -4,6 +4,10 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import org.apache.catalina.router.FrontControllerFactory;
 import org.apache.coyote.http11.Http11Processor;
 import org.slf4j.Logger;
@@ -15,17 +19,26 @@ public class Connector implements Runnable {
 
     private static final int DEFAULT_PORT = 8080;
     private static final int DEFAULT_ACCEPT_COUNT = 100;
+    private static final int DEFAULT_MAX_THREADS = 250;
 
     private final ServerSocket serverSocket;
     private boolean stopped;
+    private final ExecutorService executor;
 
     public Connector() {
-        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT);
+        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT, DEFAULT_MAX_THREADS);
     }
 
-    public Connector(final int port, final int acceptCount) {
+    public Connector(final int port, final int acceptCount, final int maxThreads) {
         this.serverSocket = createServerSocket(port, acceptCount);
         this.stopped = false;
+        this.executor = new ThreadPoolExecutor(
+                maxThreads,
+                maxThreads,
+                60L, TimeUnit.SECONDS,
+                new ArrayBlockingQueue<>(100),
+                new ThreadPoolExecutor.AbortPolicy()
+        );
     }
 
     private ServerSocket createServerSocket(final int port, final int acceptCount) {
@@ -68,7 +81,7 @@ public class Connector implements Runnable {
         }
         var frontController = FrontControllerFactory.getInstance();
         var processor = new Http11Processor(connection, frontController);
-        new Thread(processor).start();
+        executor.execute(processor);
     }
 
     public void stop() {

--- a/tomcat/src/main/java/org/apache/coyote/http11/HttpRequest.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/HttpRequest.java
@@ -29,15 +29,6 @@ public class HttpRequest {
         return split.length > 1 ? split[1] : "";
     }
 
-    public String getQueryString() {
-        final String uri = requestLine.getPath();
-        if (!uri.contains("?")) {
-            return "";
-        }
-        final String[] split = uri.split("\\?");
-        return split.length > 1 ? split[1] : "";
-    }
-
     public String getBodyAsString() {
         return new String(body, StandardCharsets.UTF_8);
     }

--- a/tomcat/src/main/java/org/apache/coyote/http11/HttpRequest.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/HttpRequest.java
@@ -29,6 +29,15 @@ public class HttpRequest {
         return split.length > 1 ? split[1] : "";
     }
 
+    public String getQueryString() {
+        final String uri = requestLine.getPath();
+        if (!uri.contains("?")) {
+            return "";
+        }
+        final String[] split = uri.split("\\?");
+        return split.length > 1 ? split[1] : "";
+    }
+
     public String getBodyAsString() {
         return new String(body, StandardCharsets.UTF_8);
     }


### PR DESCRIPTION
안녕하세용 띠용 ❓ ❔ 

직전 단계에서 남겨주신 내용 잘 확인했어요! 제 답변을 여기에 남겨보자면

> Response객체의 생성자로 outputStream을 넘겨줘서 객체 내부에서 관리하도록 하는 건 어떨까요?

Response 객체가 자신의 데이터를 스스로 flush 하도록 유도할 수 있을테니 좋은 방식인 것 같아요!

제가 생각했던 Response 객체는 Http 응답 데이터를 표현하는 책임을 가진다고 생각했어요. 데이터를 전송하는 I/O의 책임까지 부여하면 크기가 커지진 않을까? 생각했고 HttpProcessor가 Socket으로부터 OutputStream을 꺼내오고 있으니 HttpProcessor에 두고 굳이 넘겨주지 않았던 것이었어요!

이 관점에 대해서는 어떻게 생각하시나요❓톰캣 관련된 자료를 찾아보지 않고 남기는 내용이니 편하게 말해주셔도 좋습니닷

> 요청을 처리 이후 응답의 상태를 변경하지 못하게 하는 이유가 있을까요?

Response의 상태 관리 시점과 전송 시점을 분리하여 상태 관리가 끝난 이후에는 상태를 더이상 변경하지 못 하도록 제한하여 개발자의 실수를 방지할 수 있다고 생각했어요!

이번에도 잘 부탁드려용 🙇 ❓ ❔ 